### PR TITLE
[FEAT] [REFACT] 작가가 예약을 받을 때, 예약 가능한 장소 지정, 공지사항 예약설정과 분리

### DIFF
--- a/src/main/java/com/cuk/catsnap/domain/photographer/controller/PhotographerController.java
+++ b/src/main/java/com/cuk/catsnap/domain/photographer/controller/PhotographerController.java
@@ -100,4 +100,18 @@ public class PhotographerController {
         PhotographerResponse.PhotographerReservationNotice photographerReservationNoticeDto = photographerConverter.toPhotographerReservationNotice(photographerReservationNotice);
         return ResultResponse.of(PhotographerResultCode.LOOK_UP_RESERVATION_NOTICE, photographerReservationNoticeDto);
     }
+
+    @Operation(summary = "작가가 자신의 예약 전 알림을 수정하는 API(구현 완료)", description = "작가가 자신의 예약 전 알림을 수정하는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201 SP004", description = "사진작가 자신의 예약 전 알림 변경 성공")
+    })
+    @PostMapping("/my/reservation/notice")
+    public ResultResponse<?> updateMyReservationNotice(
+            @Parameter(description = "작가의 예약 전 알림", required = true)
+            @RequestBody
+            PhotographerRequest.PhotographerReservationNotice photographerReservationNotice
+    ) {
+        photographerService.updateReservationNotice(photographerReservationNotice);
+        return ResultResponse.of(PhotographerResultCode.UPDATE_RESERVATION_NOTICE);
+    }
 }

--- a/src/main/java/com/cuk/catsnap/domain/photographer/controller/PhotographerController.java
+++ b/src/main/java/com/cuk/catsnap/domain/photographer/controller/PhotographerController.java
@@ -127,4 +127,18 @@ public class PhotographerController {
         PhotographerResponse.PhotographerReservationLocation photographerReservationLocationDto = photographerConverter.toPhotographerReservationLocation(photographerReservationLocation);
         return ResultResponse.of(PhotographerResultCode.LOOK_UP_RESERVATION_LOCATION, photographerReservationLocationDto);
     }
+
+    @Operation(summary = "작가가 자신이 예약을 받을 장소를 수정하는 API(구현 완료)", description = "작가가 자신이 예약을 받을 장소를 수정하는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201 SP006", description = "사진작가 자신의 예약 전 알림 변경 성공")
+    })
+    @PostMapping("/my/reservation/location")
+    public ResultResponse<?> updateMyReservationLocation(
+            @Parameter(description = "작가의 예약 전 알림", required = true)
+            @RequestBody
+            PhotographerRequest.PhotographerReservationLocation photographerReservationLocation
+    ) {
+        photographerService.updateReservationLocation(photographerReservationLocation);
+        return ResultResponse.of(PhotographerResultCode.UPDATE_RESERVATION_LOCATION);
+    }
 }

--- a/src/main/java/com/cuk/catsnap/domain/photographer/controller/PhotographerController.java
+++ b/src/main/java/com/cuk/catsnap/domain/photographer/controller/PhotographerController.java
@@ -1,6 +1,7 @@
 package com.cuk.catsnap.domain.photographer.controller;
 
 import com.cuk.catsnap.domain.photographer.converter.PhotographerConverter;
+import com.cuk.catsnap.domain.photographer.document.PhotographerReservationLocation;
 import com.cuk.catsnap.domain.photographer.document.PhotographerReservationNotice;
 import com.cuk.catsnap.domain.photographer.document.PhotographerSetting;
 import com.cuk.catsnap.domain.photographer.dto.PhotographerRequest;
@@ -113,5 +114,17 @@ public class PhotographerController {
     ) {
         photographerService.updateReservationNotice(photographerReservationNotice);
         return ResultResponse.of(PhotographerResultCode.UPDATE_RESERVATION_NOTICE);
+    }
+
+    @Operation(summary = "작가가 자신이 예약을 받을 장소를 조회하는 API(구현 완료)", description = "작가가 자신이 예약을 받을 장소를 조회하는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200 SP005", description = "사진작가 자신의 예약 전 알림 조회 성공")
+    })
+    @GetMapping("/my/reservation/location")
+    public ResultResponse<PhotographerResponse.PhotographerReservationLocation> lookUpMyReservationLocation(
+    ) {
+        PhotographerReservationLocation photographerReservationLocation = photographerService.getReservationLocation();
+        PhotographerResponse.PhotographerReservationLocation photographerReservationLocationDto = photographerConverter.toPhotographerReservationLocation(photographerReservationLocation);
+        return ResultResponse.of(PhotographerResultCode.LOOK_UP_RESERVATION_LOCATION, photographerReservationLocationDto);
     }
 }

--- a/src/main/java/com/cuk/catsnap/domain/photographer/controller/PhotographerController.java
+++ b/src/main/java/com/cuk/catsnap/domain/photographer/controller/PhotographerController.java
@@ -1,6 +1,7 @@
 package com.cuk.catsnap.domain.photographer.controller;
 
 import com.cuk.catsnap.domain.photographer.converter.PhotographerConverter;
+import com.cuk.catsnap.domain.photographer.document.PhotographerReservationNotice;
 import com.cuk.catsnap.domain.photographer.document.PhotographerSetting;
 import com.cuk.catsnap.domain.photographer.dto.PhotographerRequest;
 import com.cuk.catsnap.domain.photographer.dto.PhotographerResponse;
@@ -86,5 +87,17 @@ public class PhotographerController {
     ) {
         photographerService.updatePhotographerSetting(photographerSetting);
         return ResultResponse.of(PhotographerResultCode.UPDATE_MY_SETTING);
+    }
+
+    @Operation(summary = "작가가 자신의 예약 전 알림을 조회하는 API(구현 완료)", description = "작가가 자신의 예약 전 알림을 조회하는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200 SP003", description = "사진작가 자신의 예약 전 알림 조회 성공")
+    })
+    @GetMapping("/my/reservation/notice")
+    public ResultResponse<PhotographerResponse.PhotographerReservationNotice> lookUpMyReservationNotice(
+    ) {
+        PhotographerReservationNotice photographerReservationNotice = photographerService.getReservationNotice();
+        PhotographerResponse.PhotographerReservationNotice photographerReservationNoticeDto = photographerConverter.toPhotographerReservationNotice(photographerReservationNotice);
+        return ResultResponse.of(PhotographerResultCode.LOOK_UP_RESERVATION_NOTICE, photographerReservationNoticeDto);
     }
 }

--- a/src/main/java/com/cuk/catsnap/domain/photographer/converter/PhotographerConverter.java
+++ b/src/main/java/com/cuk/catsnap/domain/photographer/converter/PhotographerConverter.java
@@ -24,7 +24,6 @@ public class PhotographerConverter {
                 .autoReservationAccept(photographerSetting.getAutoReservationAccept())
                 .enableOverBooking(photographerSetting.getEnableOverBooking())
                 .preReservationDays(photographerSetting.getPreReservationDays())
-                .announcement(photographerSetting.getAnnouncement())
                 .build();
     }
 }

--- a/src/main/java/com/cuk/catsnap/domain/photographer/converter/PhotographerConverter.java
+++ b/src/main/java/com/cuk/catsnap/domain/photographer/converter/PhotographerConverter.java
@@ -1,5 +1,6 @@
 package com.cuk.catsnap.domain.photographer.converter;
 
+import com.cuk.catsnap.domain.photographer.document.PhotographerReservationNotice;
 import com.cuk.catsnap.domain.photographer.document.PhotographerSetting;
 import com.cuk.catsnap.domain.photographer.dto.PhotographerRequest;
 import com.cuk.catsnap.domain.photographer.dto.PhotographerResponse;
@@ -24,6 +25,12 @@ public class PhotographerConverter {
                 .autoReservationAccept(photographerSetting.getAutoReservationAccept())
                 .enableOverBooking(photographerSetting.getEnableOverBooking())
                 .preReservationDays(photographerSetting.getPreReservationDays())
+                .build();
+    }
+
+    public PhotographerResponse.PhotographerReservationNotice toPhotographerReservationNotice(PhotographerReservationNotice photographerReservationNotice) {
+        return PhotographerResponse.PhotographerReservationNotice.builder()
+                .content(photographerReservationNotice.getContent())
                 .build();
     }
 }

--- a/src/main/java/com/cuk/catsnap/domain/photographer/converter/PhotographerConverter.java
+++ b/src/main/java/com/cuk/catsnap/domain/photographer/converter/PhotographerConverter.java
@@ -1,5 +1,6 @@
 package com.cuk.catsnap.domain.photographer.converter;
 
+import com.cuk.catsnap.domain.photographer.document.PhotographerReservationLocation;
 import com.cuk.catsnap.domain.photographer.document.PhotographerReservationNotice;
 import com.cuk.catsnap.domain.photographer.document.PhotographerSetting;
 import com.cuk.catsnap.domain.photographer.dto.PhotographerRequest;
@@ -31,6 +32,12 @@ public class PhotographerConverter {
     public PhotographerResponse.PhotographerReservationNotice toPhotographerReservationNotice(PhotographerReservationNotice photographerReservationNotice) {
         return PhotographerResponse.PhotographerReservationNotice.builder()
                 .content(photographerReservationNotice.getContent())
+                .build();
+    }
+
+    public PhotographerResponse.PhotographerReservationLocation toPhotographerReservationLocation(PhotographerReservationLocation photographerReservationLocation) {
+        return PhotographerResponse.PhotographerReservationLocation.builder()
+                .content(photographerReservationLocation.getContent())
                 .build();
     }
 }

--- a/src/main/java/com/cuk/catsnap/domain/photographer/document/PhotographerReservationLocation.java
+++ b/src/main/java/com/cuk/catsnap/domain/photographer/document/PhotographerReservationLocation.java
@@ -1,0 +1,17 @@
+package com.cuk.catsnap.domain.photographer.document;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PhotographerReservationLocation {
+
+    String id;
+    Long photographerId;
+    String content;
+}

--- a/src/main/java/com/cuk/catsnap/domain/photographer/document/PhotographerReservationNotice.java
+++ b/src/main/java/com/cuk/catsnap/domain/photographer/document/PhotographerReservationNotice.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ReservationNotice {
+public class PhotographerReservationNotice {
 
     String id;
     Long photographerId;

--- a/src/main/java/com/cuk/catsnap/domain/photographer/document/PhotographerSetting.java
+++ b/src/main/java/com/cuk/catsnap/domain/photographer/document/PhotographerSetting.java
@@ -16,5 +16,4 @@ public class PhotographerSetting {
     private Boolean autoReservationAccept;
     private Boolean enableOverBooking;
     private Long preReservationDays;
-    private String announcement;
 }

--- a/src/main/java/com/cuk/catsnap/domain/photographer/document/ReservationNotice.java
+++ b/src/main/java/com/cuk/catsnap/domain/photographer/document/ReservationNotice.java
@@ -1,0 +1,17 @@
+package com.cuk.catsnap.domain.photographer.document;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReservationNotice {
+
+    String id;
+    Long photographerId;
+    String content;
+}

--- a/src/main/java/com/cuk/catsnap/domain/photographer/dto/PhotographerRequest.java
+++ b/src/main/java/com/cuk/catsnap/domain/photographer/dto/PhotographerRequest.java
@@ -67,4 +67,14 @@ public class PhotographerRequest {
         @Schema(description = "예약전  공지 사항")
         private String content;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "작가의 예약 가능 지역")
+    public static class PhotographerReservationLocation {
+        @Schema(description = "작가의 예약 가능 지역")
+        private String content;
+    }
 }

--- a/src/main/java/com/cuk/catsnap/domain/photographer/dto/PhotographerRequest.java
+++ b/src/main/java/com/cuk/catsnap/domain/photographer/dto/PhotographerRequest.java
@@ -56,7 +56,5 @@ public class PhotographerRequest {
         private Boolean enableOverBooking;
         @Schema(description = "작가가 예약을 현재를 기준으로 며칠 후 까지 예약을 받을지")
         private Long preReservationDays;
-        @Schema(description = "작가가 예약을 받을 때 보여줄 공지")
-        private String announcement;
     }
 }

--- a/src/main/java/com/cuk/catsnap/domain/photographer/dto/PhotographerRequest.java
+++ b/src/main/java/com/cuk/catsnap/domain/photographer/dto/PhotographerRequest.java
@@ -57,4 +57,14 @@ public class PhotographerRequest {
         @Schema(description = "작가가 예약을 현재를 기준으로 며칠 후 까지 예약을 받을지")
         private Long preReservationDays;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "예약전  공지 사항")
+    public static class PhotographerReservationNotice {
+        @Schema(description = "예약전  공지 사항")
+        private String content;
+    }
 }

--- a/src/main/java/com/cuk/catsnap/domain/photographer/dto/PhotographerResponse.java
+++ b/src/main/java/com/cuk/catsnap/domain/photographer/dto/PhotographerResponse.java
@@ -53,4 +53,12 @@ public class PhotographerResponse {
         @Schema(description = "예약전  공지 사항")
         private String content;
     }
+
+    @Getter
+    @Builder
+    @Schema(description = "작가의 예약 가능 지역")
+    public static class PhotographerReservationLocation {
+        @Schema(description = "작가의 예약 가능 지역")
+        private String content;
+    }
 }

--- a/src/main/java/com/cuk/catsnap/domain/photographer/dto/PhotographerResponse.java
+++ b/src/main/java/com/cuk/catsnap/domain/photographer/dto/PhotographerResponse.java
@@ -45,4 +45,12 @@ public class PhotographerResponse {
         @Schema(description = "작가가 예약을 현재를 기준으로 며칠 후 까지 예약을 받을지")
         private Long preReservationDays;
     }
+
+    @Getter
+    @Builder
+    @Schema(description = "예약전  공지 사항")
+    public static class PhotographerReservationNotice {
+        @Schema(description = "예약전  공지 사항")
+        private String content;
+    }
 }

--- a/src/main/java/com/cuk/catsnap/domain/photographer/dto/PhotographerResponse.java
+++ b/src/main/java/com/cuk/catsnap/domain/photographer/dto/PhotographerResponse.java
@@ -44,7 +44,5 @@ public class PhotographerResponse {
         private Boolean enableOverBooking;
         @Schema(description = "작가가 예약을 현재를 기준으로 며칠 후 까지 예약을 받을지")
         private Long preReservationDays;
-        @Schema(description = "작가가 예약을 받을 때 보여줄 공지")
-        private String announcement;
     }
 }

--- a/src/main/java/com/cuk/catsnap/domain/photographer/repository/PhotographerReservationLocationRepository.java
+++ b/src/main/java/com/cuk/catsnap/domain/photographer/repository/PhotographerReservationLocationRepository.java
@@ -27,4 +27,11 @@ public class PhotographerReservationLocationRepository {
         Query query = Query.query(Criteria.where("photographerId").is(photographerId));
         return mongoOperations.findOne(query, PhotographerReservationLocation.class);
     }
+
+    public UpdateResult updatePhotographerReservationLocation(PhotographerReservationLocation photographerReservationLocation) {
+        Query query = Query.query(Criteria.where("photographerId").is(photographerReservationLocation.getPhotographerId()));
+        Update update = new Update()
+                .set("content", photographerReservationLocation.getContent());
+        return mongoOperations.updateFirst(query, update, PhotographerReservationLocation.class);
+    }
 }

--- a/src/main/java/com/cuk/catsnap/domain/photographer/repository/PhotographerReservationLocationRepository.java
+++ b/src/main/java/com/cuk/catsnap/domain/photographer/repository/PhotographerReservationLocationRepository.java
@@ -22,4 +22,9 @@ public class PhotographerReservationLocationRepository {
                 .build();
         return mongoOperations.save(photographerReservationLocation);
     }
+
+    public PhotographerReservationLocation findByPhotographerId(Long photographerId) {
+        Query query = Query.query(Criteria.where("photographerId").is(photographerId));
+        return mongoOperations.findOne(query, PhotographerReservationLocation.class);
+    }
 }

--- a/src/main/java/com/cuk/catsnap/domain/photographer/repository/PhotographerReservationLocationRepository.java
+++ b/src/main/java/com/cuk/catsnap/domain/photographer/repository/PhotographerReservationLocationRepository.java
@@ -1,0 +1,25 @@
+package com.cuk.catsnap.domain.photographer.repository;
+
+import com.cuk.catsnap.domain.photographer.document.PhotographerReservationLocation;
+import com.mongodb.client.result.UpdateResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PhotographerReservationLocationRepository {
+
+    private final MongoOperations mongoOperations;
+
+    public PhotographerReservationLocation save(String reservationLocationContent, Long photographerId) {
+        PhotographerReservationLocation photographerReservationLocation = PhotographerReservationLocation.builder()
+                .photographerId(photographerId)
+                .content(reservationLocationContent)
+                .build();
+        return mongoOperations.save(photographerReservationLocation);
+    }
+}

--- a/src/main/java/com/cuk/catsnap/domain/photographer/repository/PhotographerReservationNoticeRepository.java
+++ b/src/main/java/com/cuk/catsnap/domain/photographer/repository/PhotographerReservationNoticeRepository.java
@@ -1,10 +1,12 @@
 package com.cuk.catsnap.domain.photographer.repository;
 
 import com.cuk.catsnap.domain.photographer.document.PhotographerReservationNotice;
+import com.mongodb.client.result.UpdateResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -24,5 +26,12 @@ public class PhotographerReservationNoticeRepository {
     public PhotographerReservationNotice findByPhotographerId(Long photographerId) {
         Query query = Query.query(Criteria.where("photographerId").is(photographerId));
         return mongoOperations.findOne(query, PhotographerReservationNotice.class);
+    }
+
+    public UpdateResult updatePhotographerReservationNotice(PhotographerReservationNotice photographerReservationNotice) {
+        Query query = Query.query(Criteria.where("photographerId").is(photographerReservationNotice.getPhotographerId()));
+        Update update = new Update()
+                .set("content", photographerReservationNotice.getContent());
+        return mongoOperations.updateFirst(query, update, PhotographerReservationNotice.class);
     }
 }

--- a/src/main/java/com/cuk/catsnap/domain/photographer/repository/PhotographerReservationNoticeRepository.java
+++ b/src/main/java/com/cuk/catsnap/domain/photographer/repository/PhotographerReservationNoticeRepository.java
@@ -1,8 +1,10 @@
 package com.cuk.catsnap.domain.photographer.repository;
 
-import com.cuk.catsnap.domain.photographer.document.ReservationNotice;
+import com.cuk.catsnap.domain.photographer.document.PhotographerReservationNotice;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -11,11 +13,16 @@ public class PhotographerReservationNoticeRepository {
 
     private final MongoOperations mongoOperations;
 
-    public ReservationNotice save(String reservationNoticeContent, Long photographerId) {
-        ReservationNotice reservationNotice = ReservationNotice.builder()
+    public PhotographerReservationNotice save(String reservationNoticeContent, Long photographerId) {
+        PhotographerReservationNotice photographerReservationNotice = PhotographerReservationNotice.builder()
                 .photographerId(photographerId)
                 .content(reservationNoticeContent)
                 .build();
-        return mongoOperations.save(reservationNotice);
+        return mongoOperations.save(photographerReservationNotice);
+    }
+
+    public PhotographerReservationNotice findByPhotographerId(Long photographerId) {
+        Query query = Query.query(Criteria.where("photographerId").is(photographerId));
+        return mongoOperations.findOne(query, PhotographerReservationNotice.class);
     }
 }

--- a/src/main/java/com/cuk/catsnap/domain/photographer/repository/PhotographerReservationNoticeRepository.java
+++ b/src/main/java/com/cuk/catsnap/domain/photographer/repository/PhotographerReservationNoticeRepository.java
@@ -1,0 +1,21 @@
+package com.cuk.catsnap.domain.photographer.repository;
+
+import com.cuk.catsnap.domain.photographer.document.ReservationNotice;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PhotographerReservationNoticeRepository {
+
+    private final MongoOperations mongoOperations;
+
+    public ReservationNotice save(String reservationNoticeContent, Long photographerId) {
+        ReservationNotice reservationNotice = ReservationNotice.builder()
+                .photographerId(photographerId)
+                .content(reservationNoticeContent)
+                .build();
+        return mongoOperations.save(reservationNotice);
+    }
+}

--- a/src/main/java/com/cuk/catsnap/domain/photographer/repository/PhotographerSettingRepository.java
+++ b/src/main/java/com/cuk/catsnap/domain/photographer/repository/PhotographerSettingRepository.java
@@ -29,8 +29,7 @@ public class PhotographerSettingRepository {
         Update update = new Update()
                 .set("autoReservationAccept", photographerSetting.getAutoReservationAccept())
                 .set("enableOverBooking", photographerSetting.getEnableOverBooking())
-                .set("preReservationDays", photographerSetting.getPreReservationDays())
-                .set("announcement", photographerSetting.getAnnouncement());
+                .set("preReservationDays", photographerSetting.getPreReservationDays());
         return mongoOperations.updateFirst(query, update, PhotographerSetting.class);
     }
 }

--- a/src/main/java/com/cuk/catsnap/domain/photographer/service/PhotographerService.java
+++ b/src/main/java/com/cuk/catsnap/domain/photographer/service/PhotographerService.java
@@ -1,5 +1,6 @@
 package com.cuk.catsnap.domain.photographer.service;
 
+import com.cuk.catsnap.domain.photographer.document.PhotographerReservationLocation;
 import com.cuk.catsnap.domain.photographer.document.PhotographerSetting;
 import com.cuk.catsnap.domain.photographer.document.PhotographerReservationNotice;
 import com.cuk.catsnap.domain.photographer.dto.PhotographerRequest;
@@ -12,4 +13,5 @@ public interface PhotographerService {
     void updatePhotographerSetting(PhotographerRequest.PhotographerSetting photographerSetting);
     PhotographerReservationNotice getReservationNotice();
     void updateReservationNotice(PhotographerRequest.PhotographerReservationNotice photographerReservationNotice);
+    PhotographerReservationLocation getReservationLocation();
 }

--- a/src/main/java/com/cuk/catsnap/domain/photographer/service/PhotographerService.java
+++ b/src/main/java/com/cuk/catsnap/domain/photographer/service/PhotographerService.java
@@ -14,4 +14,5 @@ public interface PhotographerService {
     PhotographerReservationNotice getReservationNotice();
     void updateReservationNotice(PhotographerRequest.PhotographerReservationNotice photographerReservationNotice);
     PhotographerReservationLocation getReservationLocation();
+    void updateReservationLocation(PhotographerRequest.PhotographerReservationLocation photographerReservationLocation);
 }

--- a/src/main/java/com/cuk/catsnap/domain/photographer/service/PhotographerService.java
+++ b/src/main/java/com/cuk/catsnap/domain/photographer/service/PhotographerService.java
@@ -1,6 +1,7 @@
 package com.cuk.catsnap.domain.photographer.service;
 
 import com.cuk.catsnap.domain.photographer.document.PhotographerSetting;
+import com.cuk.catsnap.domain.photographer.document.PhotographerReservationNotice;
 import com.cuk.catsnap.domain.photographer.dto.PhotographerRequest;
 
 public interface PhotographerService {
@@ -9,4 +10,5 @@ public interface PhotographerService {
     void initializeSineUpPhotographer(Long photographerId);
     PhotographerSetting getPhotographerSetting();
     void updatePhotographerSetting(PhotographerRequest.PhotographerSetting photographerSetting);
+    PhotographerReservationNotice getReservationNotice();
 }

--- a/src/main/java/com/cuk/catsnap/domain/photographer/service/PhotographerService.java
+++ b/src/main/java/com/cuk/catsnap/domain/photographer/service/PhotographerService.java
@@ -6,7 +6,7 @@ import com.cuk.catsnap.domain.photographer.dto.PhotographerRequest;
 public interface PhotographerService {
 
     void singUp(PhotographerRequest.PhotographerSignUp photographerSignUp);
-    void initializePhotographerSetting(Long photographerId);
+    void initializeSineUpPhotographer(Long photographerId);
     PhotographerSetting getPhotographerSetting();
     void updatePhotographerSetting(PhotographerRequest.PhotographerSetting photographerSetting);
 }

--- a/src/main/java/com/cuk/catsnap/domain/photographer/service/PhotographerService.java
+++ b/src/main/java/com/cuk/catsnap/domain/photographer/service/PhotographerService.java
@@ -11,4 +11,5 @@ public interface PhotographerService {
     PhotographerSetting getPhotographerSetting();
     void updatePhotographerSetting(PhotographerRequest.PhotographerSetting photographerSetting);
     PhotographerReservationNotice getReservationNotice();
+    void updateReservationNotice(PhotographerRequest.PhotographerReservationNotice photographerReservationNotice);
 }

--- a/src/main/java/com/cuk/catsnap/domain/photographer/service/PhotographerServiceImpl.java
+++ b/src/main/java/com/cuk/catsnap/domain/photographer/service/PhotographerServiceImpl.java
@@ -1,6 +1,7 @@
 package com.cuk.catsnap.domain.photographer.service;
 
 import com.cuk.catsnap.domain.photographer.converter.PhotographerConverter;
+import com.cuk.catsnap.domain.photographer.document.PhotographerReservationLocation;
 import com.cuk.catsnap.domain.photographer.document.PhotographerSetting;
 import com.cuk.catsnap.domain.photographer.document.PhotographerReservationNotice;
 import com.cuk.catsnap.domain.photographer.dto.PhotographerRequest;
@@ -100,6 +101,11 @@ public class PhotographerServiceImpl implements PhotographerService{
                 .content(photographerReservationNotice.getContent())
                 .build();
         photographerReservationNoticeRepository.updatePhotographerReservationNotice(photographerReservationNoticeDocument);
+    }
+
+    @Override
+    public PhotographerReservationLocation getReservationLocation() {
+        return photographerReservationLocationRepository.findByPhotographerId(GetAuthenticationInfo.getUserId());
     }
 
 }

--- a/src/main/java/com/cuk/catsnap/domain/photographer/service/PhotographerServiceImpl.java
+++ b/src/main/java/com/cuk/catsnap/domain/photographer/service/PhotographerServiceImpl.java
@@ -46,7 +46,7 @@ public class PhotographerServiceImpl implements PhotographerService{
         // weekdayReservationTimeMapping 생성 (예약을 형식을 요일에 매핑하는 테이블 생성)
         photographerReservationService.createJoinedPhotographerReservationTimeFormat(photographer);
         // photographerSetting 초기화
-        initializePhotographerSetting(photographer.getId());
+        initializeSineUpPhotographer(photographer.getId());
         // todo : 이용약관 동의 여부 확인
     }
 
@@ -54,7 +54,7 @@ public class PhotographerServiceImpl implements PhotographerService{
     * 작가 회원가입 시 초기화 작업
      */
     @Override
-    public void initializePhotographerSetting(Long photographerId) {
+    public void initializeSineUpPhotographer(Long photographerId) {
         PhotographerSetting photographerSetting = PhotographerSetting.builder()
                 .photographerId(photographerId)
                 .autoReservationAccept(false)

--- a/src/main/java/com/cuk/catsnap/domain/photographer/service/PhotographerServiceImpl.java
+++ b/src/main/java/com/cuk/catsnap/domain/photographer/service/PhotographerServiceImpl.java
@@ -89,4 +89,14 @@ public class PhotographerServiceImpl implements PhotographerService{
         return photographerReservationNoticeRepository.findByPhotographerId(GetAuthenticationInfo.getUserId());
     }
 
+    @Override
+    public void updateReservationNotice(PhotographerRequest.PhotographerReservationNotice photographerReservationNotice) {
+        Long photographerId = GetAuthenticationInfo.getUserId();
+        PhotographerReservationNotice photographerReservationNoticeDocument = PhotographerReservationNotice.builder()
+                .photographerId(photographerId)
+                .content(photographerReservationNotice.getContent())
+                .build();
+        photographerReservationNoticeRepository.updatePhotographerReservationNotice(photographerReservationNoticeDocument);
+    }
+
 }

--- a/src/main/java/com/cuk/catsnap/domain/photographer/service/PhotographerServiceImpl.java
+++ b/src/main/java/com/cuk/catsnap/domain/photographer/service/PhotographerServiceImpl.java
@@ -108,4 +108,14 @@ public class PhotographerServiceImpl implements PhotographerService{
         return photographerReservationLocationRepository.findByPhotographerId(GetAuthenticationInfo.getUserId());
     }
 
+    @Override
+    public void updateReservationLocation(PhotographerRequest.PhotographerReservationLocation photographerReservationLocation) {
+        Long photographerId = GetAuthenticationInfo.getUserId();
+        PhotographerReservationLocation photographerReservationLocationDocument = PhotographerReservationLocation.builder()
+                .photographerId(photographerId)
+                .content(photographerReservationLocation.getContent())
+                .build();
+        photographerReservationLocationRepository.updatePhotographerReservationLocation(photographerReservationLocationDocument);
+    }
+
 }

--- a/src/main/java/com/cuk/catsnap/domain/photographer/service/PhotographerServiceImpl.java
+++ b/src/main/java/com/cuk/catsnap/domain/photographer/service/PhotographerServiceImpl.java
@@ -6,6 +6,7 @@ import com.cuk.catsnap.domain.photographer.document.PhotographerReservationNotic
 import com.cuk.catsnap.domain.photographer.dto.PhotographerRequest;
 import com.cuk.catsnap.domain.photographer.entity.Photographer;
 import com.cuk.catsnap.domain.photographer.repository.PhotographerRepository;
+import com.cuk.catsnap.domain.photographer.repository.PhotographerReservationLocationRepository;
 import com.cuk.catsnap.domain.photographer.repository.PhotographerReservationNoticeRepository;
 import com.cuk.catsnap.domain.photographer.repository.PhotographerSettingRepository;
 import com.cuk.catsnap.domain.reservation.service.PhotographerReservationService;
@@ -26,6 +27,7 @@ public class PhotographerServiceImpl implements PhotographerService{
     private final PhotographerSettingRepository photographerSettingRepository;
     private final PhotographerConverter photographerConverter;
     private final PhotographerReservationNoticeRepository photographerReservationNoticeRepository;
+    private final PhotographerReservationLocationRepository photographerReservationLocationRepository;
 
     private final PhotographerReservationService photographerReservationService;
 
@@ -64,6 +66,7 @@ public class PhotographerServiceImpl implements PhotographerService{
                 .build();
         photographerSettingRepository.save(photographerSetting);
         photographerReservationNoticeRepository.save("", photographerId);
+        photographerReservationLocationRepository.save("", photographerId);
     }
 
     @Override

--- a/src/main/java/com/cuk/catsnap/domain/photographer/service/PhotographerServiceImpl.java
+++ b/src/main/java/com/cuk/catsnap/domain/photographer/service/PhotographerServiceImpl.java
@@ -55,7 +55,6 @@ public class PhotographerServiceImpl implements PhotographerService{
                 .autoReservationAccept(false)
                 .enableOverBooking(false)
                 .preReservationDays(14L)
-                .announcement("")
                 .build();
         photographerSettingRepository.save(photographerSetting);
     }
@@ -74,7 +73,6 @@ public class PhotographerServiceImpl implements PhotographerService{
                 .autoReservationAccept(photographerSetting.getAutoReservationAccept())
                 .enableOverBooking(photographerSetting.getEnableOverBooking())
                 .preReservationDays(photographerSetting.getPreReservationDays())
-                .announcement(photographerSetting.getAnnouncement())
                 .build();
         photographerSettingRepository.updatePhotographerSetting(photographerSettingDocument);
     }

--- a/src/main/java/com/cuk/catsnap/domain/photographer/service/PhotographerServiceImpl.java
+++ b/src/main/java/com/cuk/catsnap/domain/photographer/service/PhotographerServiceImpl.java
@@ -2,6 +2,7 @@ package com.cuk.catsnap.domain.photographer.service;
 
 import com.cuk.catsnap.domain.photographer.converter.PhotographerConverter;
 import com.cuk.catsnap.domain.photographer.document.PhotographerSetting;
+import com.cuk.catsnap.domain.photographer.document.PhotographerReservationNotice;
 import com.cuk.catsnap.domain.photographer.dto.PhotographerRequest;
 import com.cuk.catsnap.domain.photographer.entity.Photographer;
 import com.cuk.catsnap.domain.photographer.repository.PhotographerRepository;
@@ -82,4 +83,10 @@ public class PhotographerServiceImpl implements PhotographerService{
                 .build();
         photographerSettingRepository.updatePhotographerSetting(photographerSettingDocument);
     }
+
+    @Override
+    public PhotographerReservationNotice getReservationNotice() {
+        return photographerReservationNoticeRepository.findByPhotographerId(GetAuthenticationInfo.getUserId());
+    }
+
 }

--- a/src/main/java/com/cuk/catsnap/domain/photographer/service/PhotographerServiceImpl.java
+++ b/src/main/java/com/cuk/catsnap/domain/photographer/service/PhotographerServiceImpl.java
@@ -5,6 +5,7 @@ import com.cuk.catsnap.domain.photographer.document.PhotographerSetting;
 import com.cuk.catsnap.domain.photographer.dto.PhotographerRequest;
 import com.cuk.catsnap.domain.photographer.entity.Photographer;
 import com.cuk.catsnap.domain.photographer.repository.PhotographerRepository;
+import com.cuk.catsnap.domain.photographer.repository.PhotographerReservationNoticeRepository;
 import com.cuk.catsnap.domain.photographer.repository.PhotographerSettingRepository;
 import com.cuk.catsnap.domain.reservation.service.PhotographerReservationService;
 import com.cuk.catsnap.global.Exception.photographer.DuplicatedPhotographerException;
@@ -23,6 +24,7 @@ public class PhotographerServiceImpl implements PhotographerService{
     private final PhotographerRepository photographerRepository;
     private final PhotographerSettingRepository photographerSettingRepository;
     private final PhotographerConverter photographerConverter;
+    private final PhotographerReservationNoticeRepository photographerReservationNoticeRepository;
 
     private final PhotographerReservationService photographerReservationService;
 
@@ -48,6 +50,9 @@ public class PhotographerServiceImpl implements PhotographerService{
         // todo : 이용약관 동의 여부 확인
     }
 
+    /*
+    * 작가 회원가입 시 초기화 작업
+     */
     @Override
     public void initializePhotographerSetting(Long photographerId) {
         PhotographerSetting photographerSetting = PhotographerSetting.builder()
@@ -57,6 +62,7 @@ public class PhotographerServiceImpl implements PhotographerService{
                 .preReservationDays(14L)
                 .build();
         photographerSettingRepository.save(photographerSetting);
+        photographerReservationNoticeRepository.save("", photographerId);
     }
 
     @Override

--- a/src/main/java/com/cuk/catsnap/global/result/code/PhotographerResultCode.java
+++ b/src/main/java/com/cuk/catsnap/global/result/code/PhotographerResultCode.java
@@ -12,7 +12,8 @@ public enum PhotographerResultCode implements ResultCode {
     UPDATE_MY_SETTING(201, "SP002", "사진작가 자신의 환경설정 변경 성공"),
     LOOK_UP_RESERVATION_NOTICE(200, "SP003", "사진작가 자신의 에약 전 공지사항 조회 완료"),
     UPDATE_RESERVATION_NOTICE(201, "SP004", "사진작가 자신의 에약 전 공지사항 변경 완료"),
-    LOOK_UP_RESERVATION_LOCATION(200, "SP005", "사진작가 자신이 에약 예약 받을 장소 조회 완료"),;
+    LOOK_UP_RESERVATION_LOCATION(200, "SP005", "사진작가 자신이 에약 예약 받을 장소 조회 완료"),
+    UPDATE_RESERVATION_LOCATION(201, "SP006", "사진작가 자신이 에약 예약 받을 장소를 변경 완료"),;
     private final int status;
     private final String code;
     private final String message;

--- a/src/main/java/com/cuk/catsnap/global/result/code/PhotographerResultCode.java
+++ b/src/main/java/com/cuk/catsnap/global/result/code/PhotographerResultCode.java
@@ -10,7 +10,8 @@ public enum PhotographerResultCode implements ResultCode {
     PHOTOGRAPHER_SIGN_UP(201, "SP000", "사진작가 회원가입 성공"),
     LOOK_UP_MY_SETTING(200, "SP001", "사진작가 자신의 환경설정 조회 성공"),
     UPDATE_MY_SETTING(201, "SP002", "사진작가 자신의 환경설정 변경 성공"),
-    LOOK_UP_RESERVATION_NOTICE(200, "SP003", "사진작가 자신의 에약 전 공지사항 조회 완료"),;
+    LOOK_UP_RESERVATION_NOTICE(200, "SP003", "사진작가 자신의 에약 전 공지사항 조회 완료"),
+    UPDATE_RESERVATION_NOTICE(201, "SP004", "사진작가 자신의 에약 전 공지사항 변경 완료"),;
     private final int status;
     private final String code;
     private final String message;

--- a/src/main/java/com/cuk/catsnap/global/result/code/PhotographerResultCode.java
+++ b/src/main/java/com/cuk/catsnap/global/result/code/PhotographerResultCode.java
@@ -11,7 +11,8 @@ public enum PhotographerResultCode implements ResultCode {
     LOOK_UP_MY_SETTING(200, "SP001", "사진작가 자신의 환경설정 조회 성공"),
     UPDATE_MY_SETTING(201, "SP002", "사진작가 자신의 환경설정 변경 성공"),
     LOOK_UP_RESERVATION_NOTICE(200, "SP003", "사진작가 자신의 에약 전 공지사항 조회 완료"),
-    UPDATE_RESERVATION_NOTICE(201, "SP004", "사진작가 자신의 에약 전 공지사항 변경 완료"),;
+    UPDATE_RESERVATION_NOTICE(201, "SP004", "사진작가 자신의 에약 전 공지사항 변경 완료"),
+    LOOK_UP_RESERVATION_LOCATION(200, "SP005", "사진작가 자신이 에약 예약 받을 장소 조회 완료"),;
     private final int status;
     private final String code;
     private final String message;

--- a/src/main/java/com/cuk/catsnap/global/result/code/PhotographerResultCode.java
+++ b/src/main/java/com/cuk/catsnap/global/result/code/PhotographerResultCode.java
@@ -9,7 +9,8 @@ import lombok.RequiredArgsConstructor;
 public enum PhotographerResultCode implements ResultCode {
     PHOTOGRAPHER_SIGN_UP(201, "SP000", "사진작가 회원가입 성공"),
     LOOK_UP_MY_SETTING(200, "SP001", "사진작가 자신의 환경설정 조회 성공"),
-    UPDATE_MY_SETTING(201, "SP002", "사진작가 자신의 환경설정 변경 성공"),;
+    UPDATE_MY_SETTING(201, "SP002", "사진작가 자신의 환경설정 변경 성공"),
+    LOOK_UP_RESERVATION_NOTICE(200, "SP003", "사진작가 자신의 에약 전 공지사항 조회 완료"),;
     private final int status;
     private final String code;
     private final String message;


### PR DESCRIPTION
#16 

1. 작가의 예약 전 알림사항을 작가의 예약 설정 로직과 분리함.
2. 작가가 예약받을 장소를 등록하고 수정하는 API 구현.
3. 작가 회원 가입시 예약 받을 장소의 도큐먼트를 만드는 로직 추가.