### PR TITLE
[REFACT] 삭제 로직 서비스단에서 하도록 리팩토링 (#27)

### DIFF
--- a/src/main/java/com/cuk/catsnap/domain/reservation/entity/Program.java
+++ b/src/main/java/com/cuk/catsnap/domain/reservation/entity/Program.java
@@ -57,4 +57,8 @@ public class Program extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "program")
     private List<Reservation> reservationList;
+
+    public void softDelete() {
+        this.deleted = true;
+    }
 }

--- a/src/main/java/com/cuk/catsnap/domain/reservation/repository/ProgramRepository.java
+++ b/src/main/java/com/cuk/catsnap/domain/reservation/repository/ProgramRepository.java
@@ -5,18 +5,10 @@ import com.cuk.catsnap.domain.reservation.entity.Program;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ProgramRepository extends JpaRepository<Program, Long> {
-
-    @Modifying
-    @Query("UPDATE Program p SET p.deleted = true WHERE p.id = :programId and p.photographer.id = :photographerId")
-    int softDeleteByProgramIdAndPhotographerId(@Param("programId") Long programId,
-        @Param("photographerId") Long photographerId);
 
     List<Program> findByPhotographerIdAndDeletedFalse(Long photographerId);
 

--- a/src/main/java/com/cuk/catsnap/domain/reservation/service/PhotographerReservationService.java
+++ b/src/main/java/com/cuk/catsnap/domain/reservation/service/PhotographerReservationService.java
@@ -167,14 +167,18 @@ public class PhotographerReservationService {
         );
     }
 
-    public int softDeleteProgram(Long programId) {
+    public void softDeleteProgram(Long programId) {
         Long photographerId = GetAuthenticationInfo.getUserId();
-        int deletedCount = programRepository.softDeleteByProgramIdAndPhotographerId(programId,
-            photographerId);
-        if (deletedCount == 0) {
-            throw new OwnershipNotFoundException("내가 소유한 프로그램 중, 해당 프로그램을 찾을 수 없습니다.");
-        }
-        return deletedCount;
+        programRepository.findById(programId).ifPresentOrElse(
+            p -> {
+                if (p.getPhotographer().getId().equals(photographerId)) {
+                    p.softDelete();
+                } else {
+                    throw new OwnershipNotFoundException("내가 소유한 프로그램 중, 해당 프로그램을 찾을 수 없습니다.");
+                }
+            }, () -> {
+                throw new OwnershipNotFoundException("내가 소유한 프로그램 중, 해당 프로그램을 찾을 수 없습니다.");
+            });
     }
 
     public MonthReservationCheckListResponse getReservationListByMonth(LocalDate month) {


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[feat]: ~~(#issueNum)
-->

## 📌 관련 이슈

- #27 적은 수의 엔티티를 업데이트 할 때, SQL문이 아닌 서비스단에서 수행

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->

적은수의 엔티티를 수정할 때에는 서비스단에서 수행하도록 한다.
왜냐하면 모든 업데이트를 SQL로 작성할 시, 작성해야할 sql문이 너무 많아지기 때문이다.

따라서 대규모 업데이트가 아닌, 적은 수의 엔티티를 수정할 때에는 조회 후 업데이트를 서비스단에서 수행하도록 리팩토링 하였다.
