### PR TITLE
[REFACT] id로 특정 엔티티 찾을 때, 쿼리에 주인을 포함시키지 않도록 리팩토링(#31)

### DIFF
--- a/src/main/java/com/cuk/catsnap/domain/reservation/entity/WeekdayReservationTimeMapping.java
+++ b/src/main/java/com/cuk/catsnap/domain/reservation/entity/WeekdayReservationTimeMapping.java
@@ -44,4 +44,8 @@ public class WeekdayReservationTimeMapping extends BaseTimeEntity {
     public void updateReservationTimeFormatId(String reservationTimeFormatId) {
         this.reservationTimeFormatId = reservationTimeFormatId;
     }
+
+    public void reservationTimeFormatIdToNull() {
+        this.reservationTimeFormatId = null;
+    }
 }

--- a/src/main/java/com/cuk/catsnap/domain/reservation/repository/ProgramRepository.java
+++ b/src/main/java/com/cuk/catsnap/domain/reservation/repository/ProgramRepository.java
@@ -3,7 +3,6 @@ package com.cuk.catsnap.domain.reservation.repository;
 
 import com.cuk.catsnap.domain.reservation.entity.Program;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,6 +10,4 @@ import org.springframework.stereotype.Repository;
 public interface ProgramRepository extends JpaRepository<Program, Long> {
 
     List<Program> findByPhotographerIdAndDeletedFalse(Long photographerId);
-
-    Optional<Program> findByIdAndPhotographerId(Long id, Long photographerId);
 }

--- a/src/main/java/com/cuk/catsnap/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/cuk/catsnap/domain/reservation/repository/ReservationRepository.java
@@ -4,7 +4,6 @@ import com.cuk.catsnap.domain.reservation.entity.Reservation;
 import com.cuk.catsnap.domain.reservation.entity.ReservationState;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -18,9 +17,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     @EntityGraph(attributePaths = {"member", "program"})
     List<Reservation> findAllReservationWithEagerByPhotographerIdAndStartTimeBetween(
         Long photographerId, LocalDateTime startTime, LocalDateTime endTime);
-
-    Optional<Reservation> findReservationByIdAndPhotographerId(Long reservationId,
-        Long photographerId);
 
     List<Reservation> findAllByPhotographerIdAndStartTimeBetweenOrderByStartTimeAsc(
         Long photographerId, LocalDateTime startTime, LocalDateTime endTime);

--- a/src/main/java/com/cuk/catsnap/domain/reservation/repository/WeekdayReservationTimeMappingRepository.java
+++ b/src/main/java/com/cuk/catsnap/domain/reservation/repository/WeekdayReservationTimeMappingRepository.java
@@ -1,22 +1,20 @@
 package com.cuk.catsnap.domain.reservation.repository;
 
+import com.cuk.catsnap.domain.photographer.entity.Photographer;
 import com.cuk.catsnap.domain.reservation.entity.Weekday;
 import com.cuk.catsnap.domain.reservation.entity.WeekdayReservationTimeMapping;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface WeekdayReservationTimeMappingRepository extends
     JpaRepository<WeekdayReservationTimeMapping, Long> {
 
-    @Modifying
-    @Query("UPDATE WeekdayReservationTimeMapping m  SET m.reservationTimeFormatId = null WHERE m.photographer.id = :photographerId AND m.reservationTimeFormatId = :reservationTimeFormatId")
-    void updateReservationTimeFormatIdToNull(@Param("photographerId") Long photographerId,
-        @Param("reservationTimeFormatId") String reservationTimeFormatId);
+    List<WeekdayReservationTimeMapping> findByPhotographerAndReservationTimeFormatId(
+        Photographer photographer,
+        String reservationTimeFormatId);
 
     Optional<WeekdayReservationTimeMapping> findByPhotographerIdAndWeekday(Long photographerId,
         Weekday weekday);

--- a/src/main/java/com/cuk/catsnap/domain/reservation/service/MemberReservationService.java
+++ b/src/main/java/com/cuk/catsnap/domain/reservation/service/MemberReservationService.java
@@ -69,9 +69,12 @@ public class MemberReservationService {
         LocalDate startDate = memberReservationRequest.startTime().toLocalDate();
         LocalTime startTime = memberReservationRequest.startTime().toLocalTime();
         Weekday weekday = weekdayService.getWeekday(startDate);
-        Program program = programRepository.findByIdAndPhotographerId(
-                memberReservationRequest.programId(), memberReservationRequest.photographerId())
+        Program program = programRepository.findById(
+                memberReservationRequest.programId())
             .orElseThrow(() -> new NotFoundProgramException("해당 작가의 프로그램이 존재하지 않습니다."));
+        if (!program.getPhotographer().getId().equals(memberReservationRequest.photographerId())) {
+            throw new OwnershipNotFoundException("해당 작가의 프로그램이 아닙니다.");
+        }
         if (program.getDeleted()) {
             throw new DeletedProgramException("해당 작가의 프로그램이 삭제되었습니다.");
         }

--- a/src/main/java/com/cuk/catsnap/domain/reservation/service/PhotographerReservationService.java
+++ b/src/main/java/com/cuk/catsnap/domain/reservation/service/PhotographerReservationService.java
@@ -49,7 +49,7 @@ public class PhotographerReservationService {
             .toList();
         weekdayReservationTimeMappingRepository.saveAll(weekdayReservationTimeMappingList);
     }
-    
+
     public MonthReservationCheckListResponse getReservationListByMonth(LocalDate month) {
         Long photographerId = GetAuthenticationInfo.getUserId();
         LocalDateTime startOfMonth = LocalDateTime.of(month.getYear(), month.getMonthValue(), 1, 0,
@@ -91,9 +91,11 @@ public class PhotographerReservationService {
      */
     public void changeReservationState(Long reservationId, ReservationState reservationState) {
         Long photographerId = GetAuthenticationInfo.getUserId();
-        reservationRepository.findReservationByIdAndPhotographerId(reservationId, photographerId)
+        reservationRepository.findById(reservationId)
             .ifPresentOrElse(reservation -> {
-                if (isPossibleChangeReservationState(reservation, reservationState)) {
+                if (reservation.getPhotographer().getId().equals(photographerId)) {
+                    throw new OwnershipNotFoundException("내가 소유한 예약 중, 해당 예약을 찾을 수 없습니다.");
+                } else if (isPossibleChangeReservationState(reservation, reservationState)) {
                     reservation.setReservationState(reservationState);
                 } else {
                     throw new CanNotChangeReservationState("예약 상태를 변경할 수 없습니다.");


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[feat]: ~~(#issueNum)
-->

## 📌 관련 이슈

#31 [REFACT] id로 특정 엔티티 찾을 때, 쿼리에 주인을 포함시키지 않도록 리팩토링

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->
기존 : 리파지토라에서 id 찾기와 소유 검증 모두를 함(And 쿼리를 수행)
리팩토링 후 : 리파지토리에서 select를 할 때 우선 해당 id로 검색을 한 후 서비스에서 해당 엔티티가 자신의 소유인지를 검증하도록 바꿈.