### PR TITLE
[FEAT] 특정 날짜의 요일과 공휴일을 알려주는 로직 작성 (#36)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,8 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     // === Redis 의존성 추가 ===
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    // === Redis Test 의존성 추가 ===
+    testImplementation 'it.ozimov:embedded-redis:0.7.2'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
     // === Test 전용  h2데이터 베이스 추가 ===
     runtimeOnly 'com.h2database:h2'
+    // === Redis 의존성 추가 ===
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/cuk/catsnap/domain/reservation/client/HolidayClient.java
+++ b/src/main/java/com/cuk/catsnap/domain/reservation/client/HolidayClient.java
@@ -54,7 +54,6 @@ public class HolidayClient {
 
     private List<LocalDate> getHolidaysByYear(YearMonth yearMonth) {
         // 월별 휴일 정보 조회
-        System.out.println("yearMonth = " + yearMonth);
         ResponseSpec responseSpec = restClient.get()
             .uri(
                 uriBuilder -> uriBuilder

--- a/src/main/java/com/cuk/catsnap/domain/reservation/client/HolidayClient.java
+++ b/src/main/java/com/cuk/catsnap/domain/reservation/client/HolidayClient.java
@@ -1,0 +1,89 @@
+package com.cuk.catsnap.domain.reservation.client;
+
+import com.cuk.catsnap.domain.reservation.client.dto.HolidayResponse;
+import com.cuk.catsnap.global.Exception.BusinessException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClient.ResponseSpec;
+
+@Component
+public class HolidayClient {
+
+    private final RestClient restClient;
+    private final String apiKey;
+    private final ObjectMapper objectMapper;
+
+    public HolidayClient(
+        @Value("${spring.client.holiday-api.base-url}")
+        String baseUrl,
+        @Value("${spring.client.holiday-api.secret-key}")
+        String apiKey,
+        RestClient.Builder restClientBuilder,
+        ObjectMapper objectMapper) {
+        this.restClient = restClientBuilder
+            .baseUrl(baseUrl)
+            .build();
+        this.apiKey = apiKey;
+        this.objectMapper = objectMapper;
+    }
+
+    /*
+     * 현재부터 1년 동안의 휴일 정보 조회
+     */
+    public List<LocalDate> getHolidays() {
+        // 휴일 정보 조회
+        YearMonth yearMonth = YearMonth.now();
+        List<LocalDate> holidays
+            = Stream.iterate(yearMonth, ym -> ym.plusYears(1))
+            .limit(2)
+            .flatMap(ym -> getHolidaysByYear(ym).stream())
+            .filter(date -> date.isAfter(LocalDate.now()))
+            .filter(date -> date.isBefore(LocalDate.now().plusYears(1)))
+            .toList();
+        return holidays;
+    }
+
+    private List<LocalDate> getHolidaysByYear(YearMonth yearMonth) {
+        // 월별 휴일 정보 조회
+        System.out.println("yearMonth = " + yearMonth);
+        ResponseSpec responseSpec = restClient.get()
+            .uri(
+                uriBuilder -> uriBuilder
+                    .queryParam("serviceKey", apiKey)
+                    .queryParam("solYear", yearMonth.getYear())
+                    .queryParam("numOfRows", 100)
+                    .queryParam("_type", "json")
+                    .build()
+            )
+            .retrieve();
+        String body = responseSpec.body(String.class);
+        List<LocalDate> holidays;
+        try {
+            HolidayResponse holidayResponse = objectMapper.readValue(body, HolidayResponse.class);
+            holidays = parseHolidays(holidayResponse);
+        } catch (JsonProcessingException e) {
+            throw new BusinessException("휴일 정보 조회 중 오류가 발생했습니다.");
+        }
+        return holidays;
+    }
+
+    private List<LocalDate> parseHolidays(HolidayResponse holidayResponse) {
+        List<LocalDate> holidays = new ArrayList<>();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+        holidayResponse.response().body().items().item().forEach(item -> {
+            String dateString = String.valueOf(item.locdate());
+            LocalDate date = LocalDate.parse(dateString, formatter);
+            holidays.add(date);
+        });
+        return holidays;
+    }
+}

--- a/src/main/java/com/cuk/catsnap/domain/reservation/client/dto/HolidayResponse.java
+++ b/src/main/java/com/cuk/catsnap/domain/reservation/client/dto/HolidayResponse.java
@@ -1,0 +1,45 @@
+package com.cuk.catsnap.domain.reservation.client.dto;
+
+import java.util.List;
+
+// RootResponse.java
+public record HolidayResponse(
+    Response response
+) {
+
+    public record Response(
+        Header header,
+        Body body
+    ) {
+
+        public record Header(
+            String resultCode,
+            String resultMsg
+        ) {
+
+        }
+
+        public record Body(
+            Items items,
+            Integer numOfRows,
+            Integer pageNo,
+            Integer totalCount
+        ) {
+
+            public record Items(
+                List<Item> item
+            ) {
+
+                public record Item(
+                    String dateKind,
+                    String dateName,
+                    String isHoliday,
+                    Integer locdate,
+                    Integer seq
+                ) {
+
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/cuk/catsnap/domain/reservation/document/Holiday.java
+++ b/src/main/java/com/cuk/catsnap/domain/reservation/document/Holiday.java
@@ -1,0 +1,17 @@
+package com.cuk.catsnap.domain.reservation.document;
+
+import jakarta.persistence.Id;
+import java.time.LocalDate;
+import org.springframework.data.redis.core.RedisHash;
+
+@RedisHash(value = "Holiday", timeToLive = 60 * 60 * 24 * 365) // 365일
+public class Holiday {
+
+    @Id
+    private String id;
+
+    public Holiday(LocalDate date) {
+        this.id = date.toString();
+        this.id = id;
+    }
+}

--- a/src/main/java/com/cuk/catsnap/domain/reservation/repository/HolidayRepository.java
+++ b/src/main/java/com/cuk/catsnap/domain/reservation/repository/HolidayRepository.java
@@ -1,0 +1,11 @@
+package com.cuk.catsnap.domain.reservation.repository;
+
+import com.cuk.catsnap.domain.reservation.document.Holiday;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface HolidayRepository extends CrudRepository<Holiday, String> {
+
+
+}

--- a/src/main/java/com/cuk/catsnap/domain/reservation/service/HolidayService.java
+++ b/src/main/java/com/cuk/catsnap/domain/reservation/service/HolidayService.java
@@ -1,0 +1,38 @@
+package com.cuk.catsnap.domain.reservation.service;
+
+import com.cuk.catsnap.domain.reservation.client.HolidayClient;
+import com.cuk.catsnap.domain.reservation.document.Holiday;
+import com.cuk.catsnap.domain.reservation.repository.HolidayRepository;
+import jakarta.annotation.PostConstruct;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class HolidayService {
+
+    private final HolidayRepository holidayRepository;
+    private final HolidayClient holidayClient;
+    @Value("${spring.env}")
+    String env;
+
+    @Scheduled(cron = "${spring.holiday.schedule.cron}")
+    public void saveHolidays() {
+        List<LocalDate> holidays = holidayClient.getHolidays();
+        holidays.forEach(holiday -> {
+            holidayRepository.save(new Holiday(holiday));
+        });
+    }
+
+    @PostConstruct
+    public void init(
+    ) {
+        if (!env.equals("test")) {
+            saveHolidays();
+        }
+    }
+}

--- a/src/main/java/com/cuk/catsnap/domain/reservation/service/HolidayService.java
+++ b/src/main/java/com/cuk/catsnap/domain/reservation/service/HolidayService.java
@@ -28,6 +28,10 @@ public class HolidayService {
         });
     }
 
+    public Boolean isHoliday(LocalDate date) {
+        return holidayRepository.findById(date.toString()).isPresent();
+    }
+
     @PostConstruct
     public void init(
     ) {

--- a/src/main/java/com/cuk/catsnap/domain/reservation/service/WeekdayService.java
+++ b/src/main/java/com/cuk/catsnap/domain/reservation/service/WeekdayService.java
@@ -2,15 +2,20 @@ package com.cuk.catsnap.domain.reservation.service;
 
 import com.cuk.catsnap.domain.reservation.entity.Weekday;
 import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class WeekdayService {
 
-    /*
-     * todo : 공휴일을 체크하는 로직이 없음. 공휴일을 체크하는 로직을 추가해야함.
-     */
+    private final HolidayService holidayService;
+
     public Weekday getWeekday(LocalDate date) {
-        return Weekday.valueOf(date.getDayOfWeek().name());
+        if (holidayService.isHoliday(date)) {
+            return Weekday.HOLIDAY;
+        } else {
+            return Weekday.valueOf(date.getDayOfWeek().name());
+        }
     }
 }

--- a/src/main/java/com/cuk/catsnap/global/data/jpa/confiog/JpaConfig.java
+++ b/src/main/java/com/cuk/catsnap/global/data/jpa/confiog/JpaConfig.java
@@ -1,4 +1,4 @@
-package com.cuk.catsnap.global.jpa.confiog;
+package com.cuk.catsnap.global.data.jpa.confiog;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;

--- a/src/main/java/com/cuk/catsnap/global/data/redis/config/RedisConfig.java
+++ b/src/main/java/com/cuk/catsnap/global/data/redis/config/RedisConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
 
 @Configuration
 public class RedisConfig {
@@ -18,5 +19,12 @@ public class RedisConfig {
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
     }
 }

--- a/src/main/java/com/cuk/catsnap/global/data/redis/config/RedisConfig.java
+++ b/src/main/java/com/cuk/catsnap/global/data/redis/config/RedisConfig.java
@@ -1,0 +1,22 @@
+package com.cuk.catsnap.global.data.redis.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+}

--- a/src/main/java/com/cuk/catsnap/global/entity/BaseTimeEntity.java
+++ b/src/main/java/com/cuk/catsnap/global/entity/BaseTimeEntity.java
@@ -15,7 +15,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public abstract class BaseTimeEntity {
 
     @CreatedDate
-    @Column(name = "created_at", nullable = false, updatable = false)
+    @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
     @LastModifiedDate
     @Column(name = "updated_at")

--- a/src/main/java/com/cuk/catsnap/global/scheduling/config/SchedulingConfig.java
+++ b/src/main/java/com/cuk/catsnap/global/scheduling/config/SchedulingConfig.java
@@ -1,0 +1,10 @@
+package com.cuk.catsnap.global.scheduling.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+
+}

--- a/src/test/java/com/cuk/catsnap/domain/reservation/client/HolidayClientTest.java
+++ b/src/test/java/com/cuk/catsnap/domain/reservation/client/HolidayClientTest.java
@@ -1,0 +1,524 @@
+package com.cuk.catsnap.domain.reservation.client;
+
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import java.time.LocalDate;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+@RestClientTest(HolidayClient.class)
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class HolidayClientTest {
+
+    @Autowired
+    private HolidayClient holidayClient;
+
+    @Autowired
+    private MockRestServiceServer mockServer;
+
+    @Value("${spring.client.holiday-api.base-url}")
+    String baseUrl;
+
+    @Value("${spring.client.holiday-api.secret-key}")
+    String apiKey;
+
+    @BeforeEach
+    void setUp() {
+        String expectedResult1 =
+            """
+                {
+                    "response": {
+                        "header": {
+                            "resultCode": "00",
+                            "resultMsg": "NORMAL SERVICE."
+                        },
+                        "body": {
+                            "items": {
+                                "item": [
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "1월1일",
+                                        "isHoliday": "Y",
+                                        "locdate": 20240101,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "설날",
+                                        "isHoliday": "Y",
+                                        "locdate": 20240209,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "설날",
+                                        "isHoliday": "Y",
+                                        "locdate": 20240210,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "설날",
+                                        "isHoliday": "Y",
+                                        "locdate": 20240211,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "대체공휴일(설날)",
+                                        "isHoliday": "Y",
+                                        "locdate": 20240212,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "삼일절",
+                                        "isHoliday": "Y",
+                                        "locdate": 20240301,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "국회의원선거",
+                                        "isHoliday": "Y",
+                                        "locdate": 20240410,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "어린이날",
+                                        "isHoliday": "Y",
+                                        "locdate": 20240505,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "대체공휴일(어린이날)",
+                                        "isHoliday": "Y",
+                                        "locdate": 20240506,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "부처님오신날",
+                                        "isHoliday": "Y",
+                                        "locdate": 20240515,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "현충일",
+                                        "isHoliday": "Y",
+                                        "locdate": 20240606,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "광복절",
+                                        "isHoliday": "Y",
+                                        "locdate": 20240815,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "추석",
+                                        "isHoliday": "Y",
+                                        "locdate": 20240916,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "추석",
+                                        "isHoliday": "Y",
+                                        "locdate": 20240917,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "추석",
+                                        "isHoliday": "Y",
+                                        "locdate": 20240918,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "임시공휴일",
+                                        "isHoliday": "Y",
+                                        "locdate": 20241001,
+                                        "seq": 2
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "개천절",
+                                        "isHoliday": "Y",
+                                        "locdate": 20241003,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "한글날",
+                                        "isHoliday": "Y",
+                                        "locdate": 20241009,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "기독탄신일",
+                                        "isHoliday": "Y",
+                                        "locdate": 20241225,
+                                        "seq": 1
+                                    }
+                                ]
+                            },
+                            "numOfRows": 100,
+                            "pageNo": 1,
+                            "totalCount": 19
+                        }
+                    }
+                } 
+                """;
+
+        String expectedResult2 =
+            """
+                {
+                    "response": {
+                        "header": {
+                            "resultCode": "00",
+                            "resultMsg": "NORMAL SERVICE."
+                        },
+                        "body": {
+                            "items": {
+                                "item": [
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "1월1일",
+                                        "isHoliday": "Y",
+                                        "locdate": 20250101,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "설날",
+                                        "isHoliday": "Y",
+                                        "locdate": 20250128,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "설날",
+                                        "isHoliday": "Y",
+                                        "locdate": 20250129,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "설날",
+                                        "isHoliday": "Y",
+                                        "locdate": 20250130,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "삼일절",
+                                        "isHoliday": "Y",
+                                        "locdate": 20250301,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "대체공휴일",
+                                        "isHoliday": "Y",
+                                        "locdate": 20250303,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "어린이날",
+                                        "isHoliday": "Y",
+                                        "locdate": 20250505,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "부처님오신날",
+                                        "isHoliday": "Y",
+                                        "locdate": 20250505,
+                                        "seq": 2
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "대체공휴일",
+                                        "isHoliday": "Y",
+                                        "locdate": 20250506,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "현충일",
+                                        "isHoliday": "Y",
+                                        "locdate": 20250606,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "광복절",
+                                        "isHoliday": "Y",
+                                        "locdate": 20250815,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "개천절",
+                                        "isHoliday": "Y",
+                                        "locdate": 20251003,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "추석",
+                                        "isHoliday": "Y",
+                                        "locdate": 20251005,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "추석",
+                                        "isHoliday": "Y",
+                                        "locdate": 20251006,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "추석",
+                                        "isHoliday": "Y",
+                                        "locdate": 20251007,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "대체공휴일",
+                                        "isHoliday": "Y",
+                                        "locdate": 20251008,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "한글날",
+                                        "isHoliday": "Y",
+                                        "locdate": 20251009,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "기독탄신일",
+                                        "isHoliday": "Y",
+                                        "locdate": 20251225,
+                                        "seq": 1
+                                    }
+                                ]
+                            },
+                            "numOfRows": 100,
+                            "pageNo": 1,
+                            "totalCount": 18
+                        }
+                    }
+                }
+                """;
+
+        String expectedResult3 =
+            """
+                {
+                    "response": {
+                        "header": {
+                            "resultCode": "00",
+                            "resultMsg": "NORMAL SERVICE."
+                        },
+                        "body": {
+                            "items": {
+                                "item": [
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "1월1일",
+                                        "isHoliday": "Y",
+                                        "locdate": 20260101,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "설날",
+                                        "isHoliday": "Y",
+                                        "locdate": 20260216,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "설날",
+                                        "isHoliday": "Y",
+                                        "locdate": 20260217,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "설날",
+                                        "isHoliday": "Y",
+                                        "locdate": 20260218,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "삼일절",
+                                        "isHoliday": "Y",
+                                        "locdate": 20260301,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "대체공휴일(삼일절)",
+                                        "isHoliday": "Y",
+                                        "locdate": 20260302,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "어린이날",
+                                        "isHoliday": "Y",
+                                        "locdate": 20260505,
+                                        "seq": 2
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "부처님오신날",
+                                        "isHoliday": "Y",
+                                        "locdate": 20260524,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "대체공휴일(부처님오신날)",
+                                        "isHoliday": "Y",
+                                        "locdate": 20260525,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "전국동시지방선거",
+                                        "isHoliday": "Y",
+                                        "locdate": 20260603,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "현충일",
+                                        "isHoliday": "Y",
+                                        "locdate": 20260606,
+                                        "seq": 2
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "광복절",
+                                        "isHoliday": "Y",
+                                        "locdate": 20260815,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "대체공휴일(광복절)",
+                                        "isHoliday": "Y",
+                                        "locdate": 20260817,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "추석",
+                                        "isHoliday": "Y",
+                                        "locdate": 20260924,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "추석",
+                                        "isHoliday": "Y",
+                                        "locdate": 20260925,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "추석",
+                                        "isHoliday": "Y",
+                                        "locdate": 20260926,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "개천절",
+                                        "isHoliday": "Y",
+                                        "locdate": 20261003,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "대체공휴일(개천절)",
+                                        "isHoliday": "Y",
+                                        "locdate": 20261005,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "한글날",
+                                        "isHoliday": "Y",
+                                        "locdate": 20261009,
+                                        "seq": 1
+                                    },
+                                    {
+                                        "dateKind": "01",
+                                        "dateName": "기독탄신일",
+                                        "isHoliday": "Y",
+                                        "locdate": 20261225,
+                                        "seq": 1
+                                    }
+                                ]
+                            },
+                            "numOfRows": 100,
+                            "pageNo": 1,
+                            "totalCount": 20
+                        }
+                    }
+                }
+                """;
+        mockServer.expect(
+                requestTo(baseUrl + "?serviceKey=" + apiKey + "&solYear=" + "2024"
+                    + "&numOfRows=100&_type=json"))
+            .andRespond(withSuccess(expectedResult1, MediaType.APPLICATION_JSON));
+        mockServer.expect(
+                requestTo(baseUrl + "?serviceKey=" + apiKey + "&solYear=" + "2025"
+                    + "&numOfRows=100&_type=json"))
+            .andRespond(withSuccess(expectedResult2, MediaType.APPLICATION_JSON));
+        mockServer.expect(
+                requestTo(baseUrl + "?serviceKey=" + apiKey + "&solYear=" + "2026"
+                    + "&numOfRows=100&_type=json"))
+            .andRespond(withSuccess(expectedResult3, MediaType.APPLICATION_JSON));
+    }
+
+    @Test
+    void 공휴일_API_호출() {
+        // given,when
+        List<LocalDate> localDateList = holidayClient.getHolidays();
+
+        //then
+        Assertions.assertThat(localDateList.size()).isNotEqualTo(0);
+        Assertions.assertThat(localDateList.get(0)).isAfterOrEqualTo(LocalDate.now());
+        Assertions.assertThat(localDateList.get(localDateList.size() - 1))
+            .isBeforeOrEqualTo(LocalDate.now().plusYears(1));
+    }
+}

--- a/src/test/java/com/cuk/catsnap/domain/reservation/repository/ReservationRepositoryTest.java
+++ b/src/test/java/com/cuk/catsnap/domain/reservation/repository/ReservationRepositoryTest.java
@@ -7,6 +7,7 @@ import com.cuk.catsnap.domain.photographer.repository.PhotographerRepository;
 import com.cuk.catsnap.domain.reservation.entity.Program;
 import com.cuk.catsnap.domain.reservation.entity.Reservation;
 import com.cuk.catsnap.domain.reservation.entity.ReservationState;
+import com.cuk.catsnap.global.data.jpa.confiog.JpaConfig;
 import com.cuk.catsnap.support.fixture.MemberFixture;
 import com.cuk.catsnap.support.fixture.PhotographerFixture;
 import com.cuk.catsnap.support.fixture.ProgramFixture;
@@ -19,6 +20,7 @@ import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -26,6 +28,7 @@ import org.springframework.data.domain.Slice;
 @DataJpaTest
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
+@Import(JpaConfig.class)
 class ReservationRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/cuk/catsnap/domain/reservation/service/HolidayServiceTest.java
+++ b/src/test/java/com/cuk/catsnap/domain/reservation/service/HolidayServiceTest.java
@@ -10,6 +10,8 @@ import com.cuk.catsnap.domain.reservation.document.Holiday;
 import com.cuk.catsnap.domain.reservation.repository.HolidayRepository;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
@@ -46,4 +48,20 @@ class HolidayServiceTest {
         verify(holidayRepository, times(2)).save(any(Holiday.class));
     }
 
+    @Test
+    void 공휴일_조회_후_레디스에_저장된_공휴일을_조회한다() {
+        // given
+        given(holidayRepository.findById("2021-01-01"))
+            .willReturn(Optional.of(new Holiday(LocalDate.of(2021, 1, 1))));
+
+        given(holidayRepository.findById("2021-01-02"))
+            .willReturn(Optional.empty());
+        // when
+        Boolean holiday = holidayService.isHoliday(LocalDate.of(2021, 1, 1));
+        Boolean notHoliday = holidayService.isHoliday(LocalDate.of(2021, 1, 2));
+
+        // then
+        Assertions.assertThat(holiday).isTrue();
+        Assertions.assertThat(notHoliday).isFalse();
+    }
 }

--- a/src/test/java/com/cuk/catsnap/domain/reservation/service/HolidayServiceTest.java
+++ b/src/test/java/com/cuk/catsnap/domain/reservation/service/HolidayServiceTest.java
@@ -1,0 +1,49 @@
+package com.cuk.catsnap.domain.reservation.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.cuk.catsnap.domain.reservation.client.HolidayClient;
+import com.cuk.catsnap.domain.reservation.document.Holiday;
+import com.cuk.catsnap.domain.reservation.repository.HolidayRepository;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class HolidayServiceTest {
+
+    @InjectMocks
+    private HolidayService holidayService;
+
+    @Mock
+    private HolidayRepository holidayRepository;
+
+    @Mock
+    private HolidayClient holidayClient;
+
+    @Test
+    void 공휴일을_조회한_후_레디스에_저장한다() {
+        // given
+        given(holidayClient.getHolidays()).willReturn(List.of(
+            LocalDate.of(2021, 1, 1), LocalDate.of(2021, 3, 1)));
+        given(holidayRepository.save(any())).willReturn(null);
+
+        // when
+        holidayService.saveHolidays();
+
+        // then
+        verify(holidayRepository, times(2)).save(any(Holiday.class));
+    }
+
+}

--- a/src/test/java/com/cuk/catsnap/domain/reservation/service/WeekdayServiceTest.java
+++ b/src/test/java/com/cuk/catsnap/domain/reservation/service/WeekdayServiceTest.java
@@ -1,0 +1,46 @@
+package com.cuk.catsnap.domain.reservation.service;
+
+import static org.mockito.BDDMockito.given;
+
+import com.cuk.catsnap.domain.reservation.entity.Weekday;
+import java.time.LocalDate;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class WeekdayServiceTest {
+
+    @InjectMocks
+    private WeekdayService weekdayService;
+
+    @Mock
+    private HolidayService holidayService;
+
+    @ParameterizedTest
+    @CsvSource({
+        "2025-01-01, HOLIDAY, true",  // 공휴일
+        "2025-01-02, THURSDAY, false", // 평일(목요일)
+        "2025-01-03, FRIDAY, false"  // 평일(금요일)
+    })
+    void 요일과_공휴일_조회(LocalDate date, Weekday expectedWeekday, boolean isHoliday) {
+        // given
+        given(holidayService.isHoliday(date))
+            .willReturn(isHoliday);
+
+        // when
+        Weekday weekday = weekdayService.getWeekday(date);
+
+        // then
+        Assertions.assertThat(weekday).isEqualTo(expectedWeekday);
+    }
+
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,4 +1,5 @@
 spring:
+  env: test
   datasource:
     url: jdbc:h2:mem:test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
   jpa:
@@ -14,11 +15,18 @@ spring:
       host: localhost
       port: 27017
       database: catsnap_test
+    redis:
+      host: localhost
+      port: 6379
 
   client:
     holiday-api:
       base-url: holiday-api-url
       secret-key: secret-key
+
+  holiday:
+    schedule:
+      cron: 0 0 11 * * *
 
   security:
     jwt-key: testessztest123dsaqwgqtestestwqw

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -15,5 +15,10 @@ spring:
       port: 27017
       database: catsnap_test
 
+  client:
+    holiday-api:
+      base-url: holiday-api-url
+      secret-key: secret-key
+
   security:
     jwt-key: testessztest123dsaqwgqtestestwqw


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[feat]: ~~(#issueNum)
-->

## 📌 관련 이슈
#36 [FEAT] 특정일이 공휴일인지 확인하는 로직 추가

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->

1. 공휴일 정보를 외부 API를 통해 가져온 후, 레디스에 저장(매일 오전 11시에 정기적으로 트리거됨)
2. 특정 날짜의 요일과 공휴일을 반환하는 함수에서 레스에 해당 날짜를 검색 후, 없으면 월~일요일 중 한 개의 값을 반환. 있으면 공휴일로 반환.
