### PR TITLE
[FIX] 중복 예약이 가능한 버그 수정 (#56)

### DIFF
--- a/src/main/java/net/catsnap/domain/reservation/service/MemberReservationService.java
+++ b/src/main/java/net/catsnap/domain/reservation/service/MemberReservationService.java
@@ -262,14 +262,31 @@ public class MemberReservationService {
         reservationRepositoryList.add(
             Reservation.builder().startTime(LocalDateTime.MAX).endTime(LocalDateTime.MAX).build());
 
+        //겹치는 시간 자체가 없어야 한다.
+        LocalDateTime wantToReservationDateTime = LocalDateTime.of(wantToReservationDate,
+            wantToReservationTime);
+        LocalDateTime wantToReservationDateTimeEnd = wantToReservationDateTime.plusMinutes(
+            programDurationMinutes);
+        for (Reservation reservation : reservationRepositoryList) {
+            if (reservation.getStartTime().isAfter(wantToReservationDateTime)
+                && reservation.getEndTime().isBefore(wantToReservationDateTimeEnd)) {
+                throw new OverLappingTimeException("해당 시간대는 예약 중복으로 인해 예약이 불가능합니다.");
+            }
+            if (reservation.getStartTime().isEqual(wantToReservationDateTime)) {
+                throw new OverLappingTimeException("해당 시간대는 예약 중복으로 인해 예약이 불가능합니다.");
+            }
+        }
+
+        //reservationRepositoryList에서 종료 시간이 startTime보다 작은 값 중 가장 큰 값을 찾아야 한다.
+        //reservationRepositoryList에서 시작 시간이 endTime보다 큰 값 중 가장 작은 값을 찾아야 한다.
         for (Reservation reservation : reservationRepositoryList) {
             if (reservation.getEndTime().isBefore(startTime)) {
                 if (lastEndingBeforeStart.getEndTime().isBefore(reservation.getEndTime())) {
                     lastEndingBeforeStart = reservation;
                 }
             }
-            if (reservation.getStartTime().isAfter(endTime) && !firstStartingAfterEnd.getStartTime()
-                .isEqual(LocalDateTime.MAX)) {
+            if (reservation.getStartTime().isAfter(endTime)
+                && !firstStartingAfterEnd.getStartTime().isEqual(LocalDateTime.MAX)) {
                 firstStartingAfterEnd = reservation;
             }
         }

--- a/src/main/java/net/catsnap/domain/reservation/service/MemberReservationService.java
+++ b/src/main/java/net/catsnap/domain/reservation/service/MemberReservationService.java
@@ -291,8 +291,8 @@ public class MemberReservationService {
             }
         }
 
-        Duration duration = Duration.between(firstStartingAfterEnd.getEndTime(),
-            lastEndingBeforeStart.getStartTime());
+        Duration duration = Duration.between(lastEndingBeforeStart.getEndTime(),
+            firstStartingAfterEnd.getStartTime());
         if (duration.toMinutes() >= programDurationMinutes) {
             return true;
         } else {


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[feat]: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #56 

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->
![image](https://github.com/user-attachments/assets/a1d4e72a-0349-477e-a34a-3d7c5e5b9ae2)
현재 예약 중복 확인은,
이미 예약된 예약 중 종료 시간이 예약을 하고자 하는 시간보다 작은 값 중 가장 큰 값과
이미 예약된 예약 중 시작 시간이 예약을 하고자 하는 시간보다 큰 값 중 가장 작은 값을 찾는다.
그 후, 이 두 구간의 차이가 현재 예약하고자 하는 시간보다 더 큰지를 확인한다.

그런데 이러한 방법은 아래와 같은 것을 확인하지 못한다.
![image](https://github.com/user-attachments/assets/d7ae979a-3282-4810-a9eb-fe1a4be346ce)

따라서, 예약을 원하는 시작시간과 종료시간 사이에 예약이 존재하는 지를 확인하는 로직을 추가하였다.

또한 두 구간의 차이를 잘못구해서(큰 값에서 작은 값을 빼야 하지만, 작은값에서 큰 값을 빼고 있었음) 이 부분을 옳바르게 계산해도록 했다.
