### PR TITLE
[REFACT] 예약을 생성하는 것과 예약을 생성할 때 검증해야 하는 로직 분리 #60

### DIFF
--- a/src/main/java/net/catsnap/domain/reservation/service/MemberReservationService.java
+++ b/src/main/java/net/catsnap/domain/reservation/service/MemberReservationService.java
@@ -94,7 +94,9 @@ public class MemberReservationService {
             photographerSetting)) {
             throw new CanNotReserveAfterDeadline("해당 작가는 해당 일에 예약을 받을 수 없습니다.");
         }
-        isAfterNow(memberReservationRequest.startTime());
+        if (!reservationValidatorService.isAfterNow(memberReservationRequest.startTime())) {
+            throw new CanNotStartTimeBeforeNow("현재 시간 이전의 예약은 불가능합니다.");
+        }
         isValidStartTimeInTimeFormat(startTime, weekday, memberReservationRequest.photographerId());
         isNotOverBooking(startDate, startTime, memberReservationRequest.photographerId(),
             program.getDurationMinutes());
@@ -295,14 +297,6 @@ public class MemberReservationService {
             return true;
         } else {
             throw new OverLappingTimeException("해당 시간대는 예약 중복으로 인해 예약이 불가능합니다.");
-        }
-    }
-
-    private boolean isAfterNow(LocalDateTime startTime) {
-        if (startTime.isAfter(LocalDateTime.now())) {
-            return true;
-        } else {
-            throw new CanNotStartTimeBeforeNow("현재 시간 이전의 예약은 불가능합니다.");
         }
     }
 }

--- a/src/main/java/net/catsnap/domain/reservation/service/ReservationValidatorService.java
+++ b/src/main/java/net/catsnap/domain/reservation/service/ReservationValidatorService.java
@@ -1,0 +1,22 @@
+package net.catsnap.domain.reservation.service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import net.catsnap.domain.photographer.document.PhotographerSetting;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationValidatorService {
+
+    /*
+     * 해당 작가가 해당 일에 예약을 받을 수 있게 했는지 확인하는 메소드 입니다.
+     */
+    public boolean isWithinAllowedDays(LocalDateTime reservationDateTime,
+        PhotographerSetting photographerSetting) {
+        Long preReservationDays = photographerSetting.getPreReservationDays();
+        LocalDate reservationDate = reservationDateTime.toLocalDate();
+        return !reservationDate.isAfter(LocalDate.now().plusDays(preReservationDays));
+    }
+}

--- a/src/main/java/net/catsnap/domain/reservation/service/ReservationValidatorService.java
+++ b/src/main/java/net/catsnap/domain/reservation/service/ReservationValidatorService.java
@@ -19,4 +19,8 @@ public class ReservationValidatorService {
         LocalDate reservationDate = reservationDateTime.toLocalDate();
         return !reservationDate.isAfter(LocalDate.now().plusDays(preReservationDays));
     }
+
+    public boolean isAfterNow(LocalDateTime reservationDateTime) {
+        return reservationDateTime.isAfter(LocalDateTime.now());
+    }
 }

--- a/src/main/java/net/catsnap/domain/reservation/service/ReservationValidatorService.java
+++ b/src/main/java/net/catsnap/domain/reservation/service/ReservationValidatorService.java
@@ -1,5 +1,6 @@
 package net.catsnap.domain.reservation.service;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -7,13 +8,16 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import net.catsnap.domain.photographer.document.PhotographerSetting;
 import net.catsnap.domain.reservation.document.ReservationTimeFormat;
+import net.catsnap.domain.reservation.entity.Reservation;
 import net.catsnap.domain.reservation.entity.Weekday;
 import net.catsnap.domain.reservation.entity.WeekdayReservationTimeMapping;
+import net.catsnap.domain.reservation.repository.ReservationRepository;
 import net.catsnap.domain.reservation.repository.ReservationTimeFormatRepository;
 import net.catsnap.domain.reservation.repository.WeekdayReservationTimeMappingRepository;
 import net.catsnap.global.Exception.authority.ResourceNotFoundException;
 import net.catsnap.global.Exception.reservation.NotFoundStartTimeException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +26,7 @@ public class ReservationValidatorService {
     private final WeekdayReservationTimeMappingRepository weekdayReservationTimeMappingRepository;
     private final ReservationTimeFormatRepository reservationTimeFormatRepository;
     private final WeekdayService weekdayService;
+    private final ReservationRepository reservationRepository;
 
     /*
      * 해당 작가가 해당 일에 예약을 받을 수 있게 했는지 확인하는 메소드 입니다.
@@ -41,6 +46,7 @@ public class ReservationValidatorService {
      * 해당 일에 사용자가 원하는 예약 시작 시간이 작가의 예약 시간 테이블에 존재하는지 확인하는 메소드 입니다.
      * wantToReservationTime는 HH:mm형식으로 들어옵니다.
      */
+    @Transactional(readOnly = true)
     public boolean isValidStartTimeInTimeFormat(LocalDateTime reservationDateTime,
         Long photographerId) {
         Weekday weekday = weekdayService.getWeekday(reservationDateTime.toLocalDate());
@@ -63,4 +69,62 @@ public class ReservationValidatorService {
         return photographerStartTimeList.contains(reservationDateTime.toLocalTime());
     }
 
+    /*
+     * 해당 일에 해당 작가의 예약을 조회하고, 시간이 겹치는지 확인하는 메소드 입니다.
+     */
+    @Transactional(readOnly = true)
+    public boolean isNotOverBooking(LocalDateTime reservationDateTime, Long photographerId,
+        Long programDurationMinutes) {
+        final int dayOfBothSide = 1;//만약, 예약 시간이 00시 이면, 전날도 고려해야 하므로 하루 전 예약 또한 고려 해야 한다.
+        LocalDateTime previousReservationDay = reservationDateTime.minusDays(dayOfBothSide);
+        LocalDateTime nextReservationDay = reservationDateTime.plusDays(dayOfBothSide);
+
+        List<Reservation> reservationRepositoryList = reservationRepository.findAllByPhotographerIdAndStartTimeBetweenOrderByStartTimeAsc(
+            photographerId, previousReservationDay, nextReservationDay);
+
+        //reservationRepositoryList에서 종료 시간이 startTime보다 작은 값 중 가장 큰 값을 찾아야 한다.
+        //reservationRepositoryList에서 시작 시간이 endTime보다 큰 값 중 가장 작은 값을 찾아야 한다.
+        Reservation lastEndingBeforeStart = Reservation.builder().startTime(LocalDateTime.MIN)
+            .endTime(LocalDateTime.MIN).build();
+        Reservation firstStartingAfterEnd = Reservation.builder().startTime(LocalDateTime.MAX)
+            .endTime(LocalDateTime.MAX).build();
+
+        //처음과 마직막에 더미 데이터를 넣어준다.
+        reservationRepositoryList.add(0,
+            Reservation.builder().startTime(LocalDateTime.MIN).endTime(LocalDateTime.MIN)
+                .build()); //불편...
+        reservationRepositoryList.add(
+            Reservation.builder().startTime(LocalDateTime.MAX).endTime(LocalDateTime.MAX).build());
+
+        //겹치는 시간 자체가 없어야 한다.
+        LocalDateTime wantToReservationDateTimeEnd = reservationDateTime.plusMinutes(
+            programDurationMinutes);
+        for (Reservation reservation : reservationRepositoryList) {
+            if (reservation.getStartTime().isAfter(reservationDateTime)
+                && reservation.getEndTime().isBefore(wantToReservationDateTimeEnd)) {
+                return false;
+            }
+            if (reservation.getStartTime().isEqual(reservationDateTime)) {
+                return false;
+            }
+        }
+
+        //reservationRepositoryList에서 종료 시간이 startTime보다 작은 값 중 가장 큰 값을 찾아야 한다.
+        //reservationRepositoryList에서 시작 시간이 endTime보다 큰 값 중 가장 작은 값을 찾아야 한다.
+        for (Reservation reservation : reservationRepositoryList) {
+            if (reservation.getEndTime().isBefore(previousReservationDay)) {
+                if (lastEndingBeforeStart.getEndTime().isBefore(reservation.getEndTime())) {
+                    lastEndingBeforeStart = reservation;
+                }
+            }
+            if (reservation.getStartTime().isAfter(nextReservationDay)
+                && !firstStartingAfterEnd.getStartTime().isEqual(LocalDateTime.MAX)) {
+                firstStartingAfterEnd = reservation;
+            }
+        }
+
+        Duration duration = Duration.between(lastEndingBeforeStart.getEndTime(),
+            firstStartingAfterEnd.getStartTime());
+        return duration.toMinutes() >= programDurationMinutes;
+    }
 }

--- a/src/main/java/net/catsnap/domain/reservation/service/ReservationValidatorService.java
+++ b/src/main/java/net/catsnap/domain/reservation/service/ReservationValidatorService.java
@@ -15,7 +15,6 @@ import net.catsnap.domain.reservation.repository.ReservationRepository;
 import net.catsnap.domain.reservation.repository.ReservationTimeFormatRepository;
 import net.catsnap.domain.reservation.repository.WeekdayReservationTimeMappingRepository;
 import net.catsnap.global.Exception.authority.ResourceNotFoundException;
-import net.catsnap.global.Exception.reservation.NotFoundStartTimeException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -59,7 +58,7 @@ public class ReservationValidatorService {
          * 해당 작가의 해당 요일에 예약 시간 설정이 존재하지 않으면 예외 발생
          */
         if (reservationTimeFormatId == null) {
-            throw new NotFoundStartTimeException("해당 작가의 해당 요일에 예약 시간 설정이 존재하지 않습니다.");
+            return false;
         }
 
         ReservationTimeFormat reservationTimeFormat = reservationTimeFormatRepository.findById(

--- a/src/main/java/net/catsnap/domain/reservation/service/ReservationValidatorService.java
+++ b/src/main/java/net/catsnap/domain/reservation/service/ReservationValidatorService.java
@@ -2,13 +2,26 @@ package net.catsnap.domain.reservation.service;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import net.catsnap.domain.photographer.document.PhotographerSetting;
+import net.catsnap.domain.reservation.document.ReservationTimeFormat;
+import net.catsnap.domain.reservation.entity.Weekday;
+import net.catsnap.domain.reservation.entity.WeekdayReservationTimeMapping;
+import net.catsnap.domain.reservation.repository.ReservationTimeFormatRepository;
+import net.catsnap.domain.reservation.repository.WeekdayReservationTimeMappingRepository;
+import net.catsnap.global.Exception.authority.ResourceNotFoundException;
+import net.catsnap.global.Exception.reservation.NotFoundStartTimeException;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class ReservationValidatorService {
+
+    private final WeekdayReservationTimeMappingRepository weekdayReservationTimeMappingRepository;
+    private final ReservationTimeFormatRepository reservationTimeFormatRepository;
+    private final WeekdayService weekdayService;
 
     /*
      * 해당 작가가 해당 일에 예약을 받을 수 있게 했는지 확인하는 메소드 입니다.
@@ -23,4 +36,31 @@ public class ReservationValidatorService {
     public boolean isAfterNow(LocalDateTime reservationDateTime) {
         return reservationDateTime.isAfter(LocalDateTime.now());
     }
+
+    /*
+     * 해당 일에 사용자가 원하는 예약 시작 시간이 작가의 예약 시간 테이블에 존재하는지 확인하는 메소드 입니다.
+     * wantToReservationTime는 HH:mm형식으로 들어옵니다.
+     */
+    public boolean isValidStartTimeInTimeFormat(LocalDateTime reservationDateTime,
+        Long photographerId) {
+        Weekday weekday = weekdayService.getWeekday(reservationDateTime.toLocalDate());
+        WeekdayReservationTimeMapping weekdayReservationTimeMapping = weekdayReservationTimeMappingRepository.findByPhotographerIdAndWeekday(
+                photographerId, weekday)
+            .orElseThrow(
+                () -> new ResourceNotFoundException("해당 작가의 해당 요일에 예약 시간 설정이 존재하지 않습니다."));
+        String reservationTimeFormatId = weekdayReservationTimeMapping.getReservationTimeFormatId();
+        /*
+         * 해당 작가의 해당 요일에 예약 시간 설정이 존재하지 않으면 예외 발생
+         */
+        if (reservationTimeFormatId == null) {
+            throw new NotFoundStartTimeException("해당 작가의 해당 요일에 예약 시간 설정이 존재하지 않습니다.");
+        }
+
+        ReservationTimeFormat reservationTimeFormat = reservationTimeFormatRepository.findById(
+            reservationTimeFormatId);
+        List<LocalTime> photographerStartTimeList = reservationTimeFormat.getStartTimeList();
+
+        return photographerStartTimeList.contains(reservationDateTime.toLocalTime());
+    }
+
 }

--- a/src/test/java/net/catsnap/domain/reservation/service/ReservationValidatorServiceTest.java
+++ b/src/test/java/net/catsnap/domain/reservation/service/ReservationValidatorServiceTest.java
@@ -1,0 +1,251 @@
+package net.catsnap.domain.reservation.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+import net.catsnap.domain.photographer.document.PhotographerSetting;
+import net.catsnap.domain.photographer.entity.Photographer;
+import net.catsnap.domain.reservation.document.ReservationTimeFormat;
+import net.catsnap.domain.reservation.entity.Reservation;
+import net.catsnap.domain.reservation.entity.Weekday;
+import net.catsnap.domain.reservation.entity.WeekdayReservationTimeMapping;
+import net.catsnap.domain.reservation.repository.ReservationRepository;
+import net.catsnap.domain.reservation.repository.ReservationTimeFormatRepository;
+import net.catsnap.domain.reservation.repository.WeekdayReservationTimeMappingRepository;
+import net.catsnap.support.fixture.PhotographerFixture;
+import net.catsnap.support.fixture.PhotographerSettingFixture;
+import net.catsnap.support.fixture.ReservationFixture;
+import net.catsnap.support.fixture.ReservationTimeFormatFixture;
+import net.catsnap.support.fixture.WeekdayReservationTimeMappingFixture;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class ReservationValidatorServiceTest {
+
+    @InjectMocks
+    private ReservationValidatorService reservationValidatorService;
+
+    @Mock
+    private WeekdayReservationTimeMappingRepository weekdayReservationTimeMappingRepository;
+    @Mock
+    private ReservationTimeFormatRepository reservationTimeFormatRepository;
+    @Mock
+    private WeekdayService weekdayService;
+    @Mock
+    private ReservationRepository reservationRepository;
+
+    @ParameterizedTest
+    @CsvSource({
+        "1, 7, true",
+        "14, 7, false"
+    })
+    void 작가가_설정한_예약일을_이내이면_true_아니면_false(Long reservationDays, Long preReservationDays,
+        Boolean expected) {
+        //given
+        LocalDateTime reservationDateTime = LocalDateTime.now().plusDays(reservationDays);
+        PhotographerSetting photographerSetting = PhotographerSettingFixture.photographerSetting()
+            .preReservationDays(preReservationDays)
+            .build();
+
+        //when
+        boolean result = reservationValidatorService.isWithinAllowedDays(reservationDateTime,
+            photographerSetting);
+        Assertions.assertThat(result).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "3, true",
+        "-2, false"
+    })
+    void 현재시간보다_이후이면_ture_아니면_false(Long reservationDays, Boolean expected) {
+        //given
+        LocalDateTime reservationDateTime = LocalDateTime.now().plusDays(reservationDays);
+        //when
+        boolean result = reservationValidatorService.isAfterNow(reservationDateTime);
+        //then
+        Assertions.assertThat(result).isEqualTo(expected);
+    }
+
+    @Nested
+    class 예약시간이_예약시간포맷에_있는지_테스트 {
+
+        @Test
+        void 예약시간이_예약시간포맷에_존재하면_ture() {
+            //given
+            Photographer photographer = PhotographerFixture.photographer()
+                .id(1L)
+                .build();
+            WeekdayReservationTimeMapping weekdayReservationTimeMapping = WeekdayReservationTimeMappingFixture.weekdayReservationTimeMapping()
+                .photographer(photographer)
+                .weekday(Weekday.MONDAY)
+                .build();
+            ReservationTimeFormat reservationTimeFormat = ReservationTimeFormatFixture.reservationTimeFormat()
+                .build();
+            given(weekdayService.getWeekday(any())).willReturn(Weekday.MONDAY);
+            given(weekdayReservationTimeMappingRepository.findByPhotographerIdAndWeekday(
+                photographer.getId(), Weekday.MONDAY))
+                .willReturn(Optional.of(weekdayReservationTimeMapping));
+            given(reservationTimeFormatRepository.findById(
+                weekdayReservationTimeMapping.getReservationTimeFormatId()))
+                .willReturn(reservationTimeFormat);
+            LocalDateTime reservationDateTime = LocalDateTime.now()
+                .withHour(reservationTimeFormat.getStartTimeList().get(0).getHour())
+                .withMinute(reservationTimeFormat.getStartTimeList().get(0).getMinute())
+                .withSecond(0)
+                .withNano(0);
+
+            //when
+            Boolean result = reservationValidatorService.isValidStartTimeInTimeFormat(
+                reservationDateTime,
+                photographer.getId());
+
+            Assertions.assertThat(result).isTrue();
+        }
+
+        @Test
+        void 예약시간이_예약시간포맷에_존재하지_않으면_false() {
+            //given
+            Photographer photographer = PhotographerFixture.photographer()
+                .id(1L)
+                .build();
+            WeekdayReservationTimeMapping weekdayReservationTimeMapping = WeekdayReservationTimeMappingFixture.weekdayReservationTimeMapping()
+                .photographer(photographer)
+                .weekday(Weekday.MONDAY)
+                .build();
+            ReservationTimeFormat reservationTimeFormat = ReservationTimeFormatFixture.reservationTimeFormat()
+                .startTimeList(List.of(LocalTime.of(10, 0), LocalTime.of(11, 0)))
+                .build();
+            given(weekdayService.getWeekday(any())).willReturn(Weekday.MONDAY);
+            given(weekdayReservationTimeMappingRepository.findByPhotographerIdAndWeekday(
+                photographer.getId(), Weekday.MONDAY))
+                .willReturn(Optional.of(weekdayReservationTimeMapping));
+            given(reservationTimeFormatRepository.findById(
+                weekdayReservationTimeMapping.getReservationTimeFormatId()))
+                .willReturn(reservationTimeFormat);
+            LocalDateTime reservationDateTime = LocalDateTime.now()
+                .withHour(23)
+                .withMinute(59)
+                .withSecond(0)
+                .withNano(0);
+
+            //when
+            Boolean result = reservationValidatorService.isValidStartTimeInTimeFormat(
+                reservationDateTime,
+                photographer.getId());
+
+            //then
+            Assertions.assertThat(result).isFalse();
+        }
+
+        @Test
+        void 작가가_해당_요일에_예약을_막은_경우_false() {
+            //given
+            Photographer photographer = PhotographerFixture.photographer()
+                .id(1L)
+                .build();
+            WeekdayReservationTimeMapping weekdayReservationTimeMapping = WeekdayReservationTimeMappingFixture.weekdayReservationTimeMapping()
+                .photographer(photographer)
+                .weekday(Weekday.MONDAY)
+                .reservationTimeFormatId(null)
+                .build();
+            given(weekdayService.getWeekday(any())).willReturn(Weekday.MONDAY);
+            given(weekdayReservationTimeMappingRepository.findByPhotographerIdAndWeekday(
+                photographer.getId(), Weekday.MONDAY))
+                .willReturn(Optional.of(weekdayReservationTimeMapping));
+            LocalDateTime reservationDateTime = LocalDateTime.now()
+                .withHour(23)
+                .withMinute(59)
+                .withSecond(0)
+                .withNano(0);
+
+            //when
+            Boolean result = reservationValidatorService.isValidStartTimeInTimeFormat(
+                reservationDateTime,
+                photographer.getId());
+
+            //then
+            Assertions.assertThat(result).isFalse();
+        }
+    }
+
+    @Nested
+    class 중복된_예약을_확인 {
+
+        @Test
+        void 중복된_예약이_없어서_true() {
+            //given
+            LocalDateTime reservationDateTime = LocalDateTime.now();
+            Long programDurationMinutes = 60L;
+            Photographer photographer = PhotographerFixture.photographer()
+                .id(1L)
+                .build();
+            Reservation reservedReservation1 = ReservationFixture.reservation()
+                .startTime(LocalDateTime.now().minusHours(3))
+                .endTime(LocalDateTime.now().minusHours(2))
+                .build();
+
+            Reservation reservedReservation2 = ReservationFixture.reservation()
+                .startTime(LocalDateTime.now().plusHours(2))
+                .endTime(LocalDateTime.now().plusHours(3))
+                .build();
+            given(
+                reservationRepository.findAllByPhotographerIdAndStartTimeBetweenOrderByStartTimeAsc(
+                    any(), any(), any()))
+                .willReturn(List.of(reservedReservation1, reservedReservation2));
+
+            //when
+            Boolean result = reservationValidatorService.isNotOverBooking(
+                reservationDateTime, photographer.getId(), programDurationMinutes);
+
+            //then
+            Assertions.assertThat(result).isTrue();
+        }
+
+        @Test
+        void 겹치는_시간의_예약이_있어_false() {
+            //given
+            LocalDateTime reservationDateTime = LocalDateTime.now();
+            Long programDurationMinutes = 60L;
+            Photographer photographer = PhotographerFixture.photographer()
+                .id(1L)
+                .build();
+            Reservation reservedReservation1 = ReservationFixture.reservation()
+                .startTime(LocalDateTime.now().minusHours(1))
+                .endTime(LocalDateTime.now().plusHours(1))
+                .build();
+
+            Reservation reservedReservation2 = ReservationFixture.reservation()
+                .startTime(LocalDateTime.now().minusHours(2))
+                .endTime(LocalDateTime.now().plusHours(3))
+                .build();
+            given(
+                reservationRepository.findAllByPhotographerIdAndStartTimeBetweenOrderByStartTimeAsc(
+                    any(), any(), any()))
+                .willReturn(List.of(reservedReservation1, reservedReservation2));
+
+            //when
+            Boolean result = reservationValidatorService.isNotOverBooking(
+                reservationDateTime, photographer.getId(), programDurationMinutes);
+
+            //then
+            Assertions.assertThat(result).isFalse();
+        }
+    }
+}

--- a/src/test/java/net/catsnap/support/fixture/PhotographerSettingFixture.java
+++ b/src/test/java/net/catsnap/support/fixture/PhotographerSettingFixture.java
@@ -1,0 +1,31 @@
+package net.catsnap.support.fixture;
+
+import net.catsnap.domain.photographer.document.PhotographerSetting;
+
+public class PhotographerSettingFixture {
+
+    private String id;
+    private Long photographerId;
+    private Boolean autoReservationAccept = true;
+    private Boolean enableOverBooking = false;
+    private Long preReservationDays = 14L;
+
+    public static PhotographerSettingFixture photographerSetting() {
+        return new PhotographerSettingFixture();
+    }
+
+    public PhotographerSettingFixture preReservationDays(Long preReservationDays) {
+        this.preReservationDays = preReservationDays;
+        return this;
+    }
+
+    public PhotographerSetting build() {
+        return PhotographerSetting.builder()
+            .id(this.id)
+            .photographerId(this.photographerId)
+            .autoReservationAccept(this.autoReservationAccept)
+            .enableOverBooking(this.enableOverBooking)
+            .preReservationDays(this.preReservationDays)
+            .build();
+    }
+}


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[feat]: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #60 

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->
리팩토링 전에는 예약을 생성하는 로직과 해당 예약이 정상적인 예약(예약 시간에 겹치는지, 현재 시간 이후의 예약인지 등)인지를 검사하는 로직이 하나의 클래스에 있었다.

리팩토링 후, 이 두 기능을 분리하였다. 예약을 검증하는 로직을 ReservationValidatorService 클래스로 분리하였다.

