### PR TITLE
[FEAT] 인증되지 않은 사용자가 발급받는 권한 정의 (#62)

### DIFF
--- a/src/main/java/net/catsnap/global/security/SecurityConfig.java
+++ b/src/main/java/net/catsnap/global/security/SecurityConfig.java
@@ -1,5 +1,12 @@
 package net.catsnap.global.security;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import javax.crypto.SecretKey;
+import lombok.RequiredArgsConstructor;
 import net.catsnap.domain.member.repository.MemberRepository;
 import net.catsnap.domain.photographer.repository.PhotographerRepository;
 import net.catsnap.global.security.authority.CatsnapAuthority;
@@ -13,13 +20,6 @@ import net.catsnap.global.security.service.MemberDetailsService;
 import net.catsnap.global.security.service.PhotographerDetailsService;
 import net.catsnap.global.security.util.JwtTokenAuthentication;
 import net.catsnap.global.security.util.ServletSecurityResponse;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import javax.crypto.SecretKey;
-import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -236,6 +236,11 @@ public class SecurityConfig {
             .authorizeHttpRequests(authorizeRequests ->
                 authorizeRequests
                     .anyRequest().permitAll()
+            )
+            .anonymous(
+                anonymousConfigurer -> anonymousConfigurer
+                    .principal("anonymous")
+                    .authorities(List.of(CatsnapAuthority.ANONYMOUS))
             );
         return http.build();
     }

--- a/src/main/java/net/catsnap/global/security/authority/CatsnapAuthority.java
+++ b/src/main/java/net/catsnap/global/security/authority/CatsnapAuthority.java
@@ -3,7 +3,7 @@ package net.catsnap.global.security.authority;
 import org.springframework.security.core.GrantedAuthority;
 
 public enum CatsnapAuthority implements GrantedAuthority {
-    MEMBER, PHOTOGRAPHER;
+    MEMBER, PHOTOGRAPHER, ANONYMOUS;
 
     @Override
     public String getAuthority() {


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[feat]: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #62 

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->
스프링 시큐리티는 AnonymousAuthenticationFilter를 통해 Authentcation이 없는 요청에 anonymous 권한을 넣어준다.

그런데 이 권한은 SimpleGrantedAuthority이기 때문에 우리 프로젝트에서 정의한 CatsnapAuthority과 타입이 불일치한다. 
따라서 CatsnapAuthority에 ANONYMOUS를 추가하고, AnonymousAuthenticationFilter에서 해당 authority를 추가하도록 하였다.
