### PR TITLE
[FEAT] 공휴일을 조회하는 API 개발 (#69)

### DIFF
--- a/src/main/java/net/catsnap/domain/reservation/client/dto/HolidayResponse.java
+++ b/src/main/java/net/catsnap/domain/reservation/client/dto/HolidayResponse.java
@@ -1,6 +1,9 @@
 package net.catsnap.domain.reservation.client.dto;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
+import net.catsnap.domain.reservation.document.Holiday;
 
 // RootResponse.java
 public record HolidayResponse(
@@ -41,5 +44,16 @@ public record HolidayResponse(
                 }
             }
         }
+    }
+
+    public List<Holiday> toEntity() {
+        return response.body.items.item.stream()
+            .map(item -> new Holiday(parseDate(item.locdate.toString()), item.dateName))
+            .toList();
+    }
+
+    private LocalDate parseDate(String dateString) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+        return LocalDate.parse(dateString, formatter);
     }
 }

--- a/src/main/java/net/catsnap/domain/reservation/controller/HolidayController.java
+++ b/src/main/java/net/catsnap/domain/reservation/controller/HolidayController.java
@@ -1,0 +1,52 @@
+package net.catsnap.domain.reservation.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.YearMonth;
+import lombok.RequiredArgsConstructor;
+import net.catsnap.domain.reservation.dto.HolidayListResponse;
+import net.catsnap.domain.reservation.service.HolidayService;
+import net.catsnap.global.result.ResultResponse;
+import net.catsnap.global.result.code.ReservationResultCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "휴일 관련 API", description = "휴일을 조회하거나 등록하는 API입니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/holiday")
+public class HolidayController {
+
+    private final HolidayService holidayService;
+
+    @Operation(summary = "공휴일 정보를 업데이트 하는 API입니다(관리자 전용)(구현완료)", description = "공휴일 정보를 업데이트 하는 API입니다(관리자 전용)")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200 SR014", description = "성공적으로 휴일 정보를 업데이트했습니다."),
+    })
+    @PostMapping
+    public ResponseEntity<ResultResponse<ReservationResultCode>> saveHolidays() {
+        holidayService.saveHolidays();
+        return ResultResponse.of(ReservationResultCode.HOLIDAY_UPDATE);
+    }
+
+    @Operation(summary = "특정 달의 공휴일 정보를 가져오는 API(구현완료)", description = "2년 내의 공휴일 정보만 가능합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200 SR015", description = "성공적으로 휴일 정보를 조회했습니다."),
+    })
+    @GetMapping
+    public ResponseEntity<ResultResponse<HolidayListResponse>> getHoliday(
+        @RequestParam("yearMonth")
+        @Parameter(description = "공휴일 조회하고 싶은 달", example = "yyyy-MM")
+        YearMonth yearMonth
+    ) {
+        HolidayListResponse holidayListResponse = holidayService.getHoliday(yearMonth);
+        return ResultResponse.of(ReservationResultCode.HOLIDAY_LOOK_UP, holidayListResponse);
+    }
+}

--- a/src/main/java/net/catsnap/domain/reservation/document/Holiday.java
+++ b/src/main/java/net/catsnap/domain/reservation/document/Holiday.java
@@ -2,6 +2,7 @@ package net.catsnap.domain.reservation.document;
 
 import jakarta.persistence.Id;
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.redis.core.RedisHash;
@@ -19,5 +20,10 @@ public class Holiday {
     public Holiday(LocalDate date, String holidayName) {
         this.id = date.toString();
         this.holidayName = holidayName;
+    }
+
+    public LocalDate idToLocalDate() {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        return LocalDate.parse(this.id, formatter);
     }
 }

--- a/src/main/java/net/catsnap/domain/reservation/document/Holiday.java
+++ b/src/main/java/net/catsnap/domain/reservation/document/Holiday.java
@@ -2,16 +2,22 @@ package net.catsnap.domain.reservation.document;
 
 import jakarta.persistence.Id;
 import java.time.LocalDate;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.redis.core.RedisHash;
 
 @RedisHash(value = "Holiday", timeToLive = 60 * 60 * 24 * 365) // 365일
+@NoArgsConstructor
+@Getter
 public class Holiday {
 
     @Id
     private String id;
 
-    public Holiday(LocalDate date) {
+    private String holidayName;
+
+    public Holiday(LocalDate date, String holidayName) {
         this.id = date.toString();
-        this.id = id;
+        this.holidayName = holidayName;
     }
 }

--- a/src/main/java/net/catsnap/domain/reservation/dto/HolidayListResponse.java
+++ b/src/main/java/net/catsnap/domain/reservation/dto/HolidayListResponse.java
@@ -1,0 +1,12 @@
+package net.catsnap.domain.reservation.dto;
+
+import java.util.List;
+
+public record HolidayListResponse(
+    List<HolidayResponse> holidayList
+) {
+
+    public static HolidayListResponse from(List<HolidayResponse> holidayList) {
+        return new HolidayListResponse(holidayList);
+    }
+}

--- a/src/main/java/net/catsnap/domain/reservation/dto/HolidayResponse.java
+++ b/src/main/java/net/catsnap/domain/reservation/dto/HolidayResponse.java
@@ -1,0 +1,20 @@
+package net.catsnap.domain.reservation.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDate;
+import net.catsnap.domain.reservation.document.Holiday;
+
+public record HolidayResponse(
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    LocalDate holidayDate,
+    String holidayName
+
+) {
+
+    public static HolidayResponse from(Holiday holiday) {
+        return new HolidayResponse(
+            holiday.idToLocalDate(),
+            holiday.getHolidayName()
+        );
+    }
+}

--- a/src/main/java/net/catsnap/domain/reservation/service/HolidayService.java
+++ b/src/main/java/net/catsnap/domain/reservation/service/HolidayService.java
@@ -1,10 +1,13 @@
 package net.catsnap.domain.reservation.service;
 
 import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import net.catsnap.domain.reservation.client.HolidayClient;
-import net.catsnap.domain.reservation.document.Holiday;
+import net.catsnap.domain.reservation.dto.HolidayListResponse;
+import net.catsnap.domain.reservation.dto.HolidayResponse;
 import net.catsnap.domain.reservation.repository.HolidayRepository;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -21,13 +24,21 @@ public class HolidayService {
 
     @Scheduled(cron = "${spring.holiday.schedule.cron}")
     public void saveHolidays() {
-        List<LocalDate> holidays = holidayClient.getHolidays();
-        holidays.forEach(holiday -> {
-            holidayRepository.save(new Holiday(holiday));
-        });
+        holidayRepository.saveAll(holidayClient.getHolidays());
     }
 
     public Boolean isHoliday(LocalDate date) {
         return holidayRepository.findById(date.toString()).isPresent();
+    }
+
+    public HolidayListResponse getHoliday(YearMonth date) {
+        List<HolidayResponse> holidayResponseList = new ArrayList<>();
+        holidayRepository.findAll()
+            .forEach(holiday -> {
+                if (holiday.getId().contains(date.toString())) {
+                    holidayResponseList.add(HolidayResponse.from(holiday));
+                }
+            });
+        return new HolidayListResponse(holidayResponseList);
     }
 }

--- a/src/main/java/net/catsnap/domain/review/controller/ReviewController.java
+++ b/src/main/java/net/catsnap/domain/review/controller/ReviewController.java
@@ -58,7 +58,7 @@ public class ReviewController {
         return ResultResponse.of(ReviewResultCode.REVIEW_LIKE_TOGGLE);
     }
 
-    @Operation(summary = "리뷰 1개를 피드 Id로 조회하는 API", description = "피드 1개를 피드 Id로 조회하는 API입니다.")
+    @Operation(summary = "리뷰 1개를 피드 Id로 조회하는 API(구현 완료)", description = "피드 1개를 피드 Id로 조회하는 API입니다.")
     @ApiResponses({
         @ApiResponse(responseCode = "200 SV002", description = "리뷰를 성공적으로 조회했습니다.")
     })

--- a/src/main/java/net/catsnap/global/result/code/ReservationResultCode.java
+++ b/src/main/java/net/catsnap/global/result/code/ReservationResultCode.java
@@ -1,8 +1,8 @@
 package net.catsnap.global.result.code;
 
-import net.catsnap.global.result.ResultCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import net.catsnap.global.result.ResultCode;
 
 @Getter
 @RequiredArgsConstructor
@@ -23,6 +23,8 @@ public enum ReservationResultCode implements ResultCode {
     PHOTOGRAPHER_DELETE_PROGRAM(200, "SR011", "성공적으로 예약 프로그램을 삭제했습니다."),
     PHOTOGRAPHER_RESERVATION_TIME_FORMAT_LOOK_UP(200, "SR012", "성공적으로 예약 시간 형식을 조회했습니다."),
     PHOTOGRAPHER_LOOK_UP_PROGRAM(200, "SR013", "성공적으로 예약 프로그램을 조회회했습니다."),
+    HOLIDAY_UPDATE(200, "SR014", "성공적으로 휴일 정보를 업데이트했습니다."),
+    HOLIDAY_LOOK_UP(200, "SR015", "성공적으로 휴일 정보를 조회했습니다."),
     ;
 
     private final int status;

--- a/src/test/java/net/catsnap/domain/reservation/client/HolidayClientTest.java
+++ b/src/test/java/net/catsnap/domain/reservation/client/HolidayClientTest.java
@@ -3,8 +3,8 @@ package net.catsnap.domain.reservation.client;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
-import java.time.LocalDate;
 import java.util.List;
+import net.catsnap.domain.reservation.document.Holiday;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -513,12 +513,9 @@ class HolidayClientTest {
     @Test
     void 공휴일_API_호출() {
         // given,when
-        List<LocalDate> localDateList = holidayClient.getHolidays();
+        List<Holiday> localDateList = holidayClient.getHolidays();
 
         //then
         Assertions.assertThat(localDateList.size()).isNotEqualTo(0);
-        Assertions.assertThat(localDateList.get(0)).isAfterOrEqualTo(LocalDate.now());
-        Assertions.assertThat(localDateList.get(localDateList.size() - 1))
-            .isBeforeOrEqualTo(LocalDate.now().plusYears(1));
     }
 }

--- a/src/test/java/net/catsnap/domain/reservation/service/HolidayServiceTest.java
+++ b/src/test/java/net/catsnap/domain/reservation/service/HolidayServiceTest.java
@@ -5,12 +5,13 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import net.catsnap.domain.reservation.client.HolidayClient;
-import net.catsnap.domain.reservation.document.Holiday;
-import net.catsnap.domain.reservation.repository.HolidayRepository;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import net.catsnap.domain.reservation.client.HolidayClient;
+import net.catsnap.domain.reservation.document.Holiday;
+import net.catsnap.domain.reservation.repository.HolidayRepository;
+import net.catsnap.support.fixture.HolidayFixture;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -37,31 +38,42 @@ class HolidayServiceTest {
     @Test
     void 공휴일을_조회한_후_레디스에_저장한다() {
         // given
-        given(holidayClient.getHolidays()).willReturn(List.of(
-            LocalDate.of(2021, 1, 1), LocalDate.of(2021, 3, 1)));
-        given(holidayRepository.save(any())).willReturn(null);
+        Holiday holiday1 = HolidayFixture.Holiday()
+            .id(LocalDate.of(2024, 1, 1))
+            .holidayName("신정")
+            .build();
+        Holiday holiday2 = HolidayFixture.Holiday()
+            .id(LocalDate.of(2024, 12, 25))
+            .holidayName("크리스마스")
+            .build();
+        given(holidayClient.getHolidays()).willReturn(List.of(holiday1, holiday2));
+        given(holidayRepository.saveAll(any())).willReturn(null);
 
         // when
         holidayService.saveHolidays();
 
         // then
-        verify(holidayRepository, times(2)).save(any(Holiday.class));
+        verify(holidayRepository, times(1)).saveAll(any());
     }
 
     @Test
     void 공휴일_조회_후_레디스에_저장된_공휴일을_조회한다() {
         // given
+        Holiday holiday = HolidayFixture.Holiday()
+            .id(LocalDate.of(2024, 1, 1))
+            .holidayName("신정")
+            .build();
         given(holidayRepository.findById("2021-01-01"))
-            .willReturn(Optional.of(new Holiday(LocalDate.of(2021, 1, 1))));
+            .willReturn(Optional.of(holiday));
 
         given(holidayRepository.findById("2021-01-02"))
             .willReturn(Optional.empty());
         // when
-        Boolean holiday = holidayService.isHoliday(LocalDate.of(2021, 1, 1));
-        Boolean notHoliday = holidayService.isHoliday(LocalDate.of(2021, 1, 2));
+        Boolean IsHoliday = holidayService.isHoliday(LocalDate.of(2021, 1, 1));
+        Boolean IsNotHoliday = holidayService.isHoliday(LocalDate.of(2021, 1, 2));
 
         // then
-        Assertions.assertThat(holiday).isTrue();
-        Assertions.assertThat(notHoliday).isFalse();
+        Assertions.assertThat(IsHoliday).isTrue();
+        Assertions.assertThat(IsNotHoliday).isFalse();
     }
 }

--- a/src/test/java/net/catsnap/domain/reservation/service/HolidayServiceTest.java
+++ b/src/test/java/net/catsnap/domain/reservation/service/HolidayServiceTest.java
@@ -6,10 +6,12 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.List;
 import java.util.Optional;
 import net.catsnap.domain.reservation.client.HolidayClient;
 import net.catsnap.domain.reservation.document.Holiday;
+import net.catsnap.domain.reservation.dto.HolidayListResponse;
 import net.catsnap.domain.reservation.repository.HolidayRepository;
 import net.catsnap.support.fixture.HolidayFixture;
 import org.assertj.core.api.Assertions;
@@ -75,5 +77,25 @@ class HolidayServiceTest {
         // then
         Assertions.assertThat(IsHoliday).isTrue();
         Assertions.assertThat(IsNotHoliday).isFalse();
+    }
+
+    @Test
+    void 특정_달의_공휴일을_조회한다() {
+        // given
+        Holiday holiday1 = HolidayFixture.Holiday()
+            .id(LocalDate.of(2024, 1, 1))
+            .holidayName("신정")
+            .build();
+        Holiday holiday2 = HolidayFixture.Holiday()
+            .id(LocalDate.of(2024, 12, 25))
+            .holidayName("크리스마스")
+            .build();
+        given(holidayRepository.findAll()).willReturn(List.of(holiday1, holiday2));
+
+        // when
+        HolidayListResponse holidayListResponse = holidayService.getHoliday(YearMonth.of(2024, 1));
+
+        // then
+        Assertions.assertThat(holidayListResponse.holidayList().size()).isEqualTo(1);
     }
 }

--- a/src/test/java/net/catsnap/support/fixture/HolidayFixture.java
+++ b/src/test/java/net/catsnap/support/fixture/HolidayFixture.java
@@ -1,0 +1,28 @@
+package net.catsnap.support.fixture;
+
+import java.time.LocalDate;
+import net.catsnap.domain.reservation.document.Holiday;
+
+public class HolidayFixture {
+
+    private String id = "2024-12-25";
+    private String holidayName = "크리스마스";
+
+    public static HolidayFixture Holiday() {
+        return new HolidayFixture();
+    }
+
+    public HolidayFixture id(LocalDate id) {
+        this.id = id.toString();
+        return this;
+    }
+
+    public HolidayFixture holidayName(String holidayName) {
+        this.holidayName = holidayName;
+        return this;
+    }
+
+    public Holiday build() {
+        return new Holiday(LocalDate.parse(id), holidayName);
+    }
+}


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[feat]: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #69 

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->
공휴일을 조회하는 API를 개발했습니다.
또한 공휴일을 명시적으로 업데이트 하도록 공휴일 업데이트 API를 개발했습니다.