### PR TITLE
[FEAT] 존재하지 않는 API호출 시, 예외 처리 (#73)

### DIFF
--- a/src/main/java/net/catsnap/global/result/GlobalBusinessExceptionHandler.java
+++ b/src/main/java/net/catsnap/global/result/GlobalBusinessExceptionHandler.java
@@ -1,11 +1,13 @@
 package net.catsnap.global.result;
 
-import net.catsnap.global.Exception.BusinessException;
-import net.catsnap.global.result.errorcode.ErrorRepository;
 import lombok.RequiredArgsConstructor;
+import net.catsnap.global.Exception.BusinessException;
+import net.catsnap.global.result.errorcode.CommonErrorCode;
+import net.catsnap.global.result.errorcode.ErrorRepository;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
 
 @RestControllerAdvice
 @RequiredArgsConstructor
@@ -18,5 +20,11 @@ public class GlobalBusinessExceptionHandler {
         ResultCode resultCode = errorRepository.getResultCode(e);
 
         return ResultResponse.of(resultCode);
+    }
+
+    @ExceptionHandler(value = NoHandlerFoundException.class)
+    public ResponseEntity<ResultResponse<ResultCode>> handleNoHandlerFoundException(
+        NoHandlerFoundException e) {
+        return ResultResponse.of(CommonErrorCode.NOT_FOUND_API);
     }
 }

--- a/src/main/java/net/catsnap/global/result/errorcode/CommonErrorCode.java
+++ b/src/main/java/net/catsnap/global/result/errorcode/CommonErrorCode.java
@@ -1,0 +1,16 @@
+package net.catsnap.global.result.errorcode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import net.catsnap.global.result.ResultCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommonErrorCode implements ResultCode {
+    NOT_FOUND_API(404, "EC000", "존재하지 않는 API 입니다."),
+    ;
+
+    private final int status;
+    private final String code;
+    private final String message;
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,4 +1,7 @@
 spring:
+  web:
+    resources:
+      add-mappings: false
   datasource:
     url: jdbc:h2:mem:test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
   jpa:


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[feat]: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #73 

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->
존재하지 않는 API 호출 시, 스프링 기본 예외 처리가 아닌, Catsnap에서 약속한 형식대로 응답을 반환하도록함.

## 📒 예외 처리 관련 분석

다른 설정을 하지 않고, 아래와 같은 예외 처리만 있으면, 존재하지 않는 API호출 한다면,
아래 예외 응답이 아닌, 기본 예외 응답을 반환합니다.

![image](https://github.com/user-attachments/assets/18570d26-8f1c-437f-8e17-2e55ff7ccbae)

DispatcherServlet클래스의 getHandler는 Request의 URL을 통해 적절한 핸들러를 반환하는 역할을 합니다.
그런데. 존재하지 않는 API를 호출했음에도, 아래 디버깅에서 특정 핸들러를 찾음을 알 수 있습니다. 

또한, 정상적인 API호출에는 RequestMappingHandlerMapping 클래스가 매핑되는 반면, 
잘못된 API 호출에는 SimpleUrlHandlerMapping이 호출되는 모습입니다.
![image](https://github.com/user-attachments/assets/f54cdd7b-19c8-459d-97cb-ebca01360b12)

또한, SimpleUrlHandlerMapping의 매핑 우선 순위는 제일 낮은 모습을 알 수 있습니다.

![image](https://github.com/user-attachments/assets/28d41bd9-7b09-4015-8aba-cff76d3fa1cb)

그래서 SimpleUrlHandlerMapping에서 어떠한 패턴이 존재하지 않는 API에 매핑되는지 확인해 보았습니다.
따라서 SimpleUrlHandlerMapping의 getHandler()함수 내부로 들어갔습니다.
![image](https://github.com/user-attachments/assets/99b7e696-6c71-4112-afb0-0ed92430c568)

상속 관계에 따라, getHandler()함수는 AbstractHandlerMapping 클래스 내부에 있고, getHandler()함수는 내부적으로 getHandlerInternal()함수를 호출하였습니다. (해당 함수는 AbstractUrlHandlerMapping 클래스의 함수입니다.)
![image](https://github.com/user-attachments/assets/7f1b4d5f-8179-4c35-a002-e8ce70cf966f)

AbstractUrlHandlerMapping 클래스의 getHandlerInternal()함수는 lookupHandler()함수를 호출하고, lookupHandler()는 DirectMatch함수를 호출합니다. (이 모든 함수는 AbstractUrlHandlerMapping클래스의 함수입니다)
![image](https://github.com/user-attachments/assets/a0767769-febe-473b-8407-32d46e7fb766)
![image](https://github.com/user-attachments/assets/90cbf609-2371-41ad-b5d0-7fe87f6ad579)

getDirectMatch()함수에서 실질적인 매핑을 수행합니다. 그런데 this.handlerMap에서 모든 경로에 매핑되는 /**경로가 존재함을 알 수 있었습니다. (또한 모든 경로는 ResourceHttpRequestHandler로 매핑됨을 알 수 있습니다.)
![image](https://github.com/user-attachments/assets/8bbef6ce-28c2-4b10-9c40-5cd614674a9b)
![image](https://github.com/user-attachments/assets/905a5f01-3976-4149-9868-fbd7821beb53)

따라서 /**경로에는 ResourceHttpRequestHandler가 매핑된 후, 핸들러를 호출합니다. (그 전에 어댑터를 선택하는 과정이 있는데, HttpRequestHandlerAdapter이 선택된다)
ResourceHttpRequestHandler는 static resource를 처리하는데 이용되는데, 해당 경로에 static resource가 없다면 예외를 발생시킵니다. 
(https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/servlet/resource/ResourceHttpRequestHandler.html)
당연하게도, 잘못된 API 호출은 해당 경로에 static Resource가 없으므로, NoResourceFoundException이 발생한다.
아래 함수는 ResourceHttpRequestHandler 클래스의 함수입니다.
![image](https://github.com/user-attachments/assets/76da89b3-a5aa-468c-a49c-a57fb5fd0401)

해당 코드의 주석에서 설명하듯이, 404 check를 먼저 하라고 되어 있습니다.
따라서 일치하지 않는 API호출이 발생 했을 때에는, 특정 핸들러가 매핑되지 않도록 해야했습니다.
이는, NoResourceFoundException을 예외처리 할 수는 있지만, 존재하지 않는 API는 해당 예외에 맞지 않다고 생각했기 때문입니다.

존재하지 않는 API에 특정 핸들러가 매핑된 이유는 /** 에 매핑된 ResourceHttpRequestHandler가 있었기 때문이고, 해당 매핑을 만들지 않는다면, 핸들러가 매핑되지 않을것 입니다.

/**경로 설정은 WebProperties 클래스에서 할 수 있고, WebProperties.Resouce.addMappings 변수를 통해 설정할 수 있습니다.
이는 application 파일의 spring.web.resources.add-mappings=false 통해 설정할 수 있습니다. 
![image](https://github.com/user-attachments/assets/4643a50f-9684-41b3-9c09-9fe44bf2961d)
(https://docs.spring.io/spring-boot/api/java/org/springframework/boot/autoconfigure/web/WebProperties.html)

해당 설정을 하게 되면, DispatcherServlet 클래스의 getHandler()함수는 null값을 반환하게 되고, noHandlerFound()함수가 호출된다.
noHandlerFound()에서, NoHandlerFoundException 예외를 발생시킵니다.
![image](https://github.com/user-attachments/assets/2c3bd14b-7b59-4ede-8c20-58c4167c4605)
![image](https://github.com/user-attachments/assets/5560266d-7cc6-44bd-a33e-5703ddd32f54)

이제, 존재하지 않는 API호출 시, NoHandlerFoundException예외가 발생하고, 해당 예외를 아래 코드와 같이 처리했습니다.
![image](https://github.com/user-attachments/assets/3a85dbe0-4e16-42a6-9525-6ed910a92e2d)


