### PR TITLE
[REFACT] 소유권 확인 로직은 엔티티 함수로 이동 (#83)

### DIFF
--- a/src/main/java/net/catsnap/domain/reservation/entity/Program.java
+++ b/src/main/java/net/catsnap/domain/reservation/entity/Program.java
@@ -1,7 +1,5 @@
 package net.catsnap.domain.reservation.entity;
 
-import net.catsnap.domain.photographer.entity.Photographer;
-import net.catsnap.global.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -16,6 +14,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import net.catsnap.domain.photographer.entity.Photographer;
+import net.catsnap.global.Exception.authority.OwnershipNotFoundException;
+import net.catsnap.global.entity.BaseTimeEntity;
 
 
 /*
@@ -60,5 +61,11 @@ public class Program extends BaseTimeEntity {
 
     public void softDelete() {
         this.deleted = true;
+    }
+    
+    public void checkOwnership(Long photographerId) {
+        if (!this.photographer.getId().equals(photographerId)) {
+            throw new OwnershipNotFoundException("내가 소유한 프로그램 중, 해당 프로그램을 찾을 수 없습니다.");
+        }
     }
 }

--- a/src/main/java/net/catsnap/domain/reservation/entity/Reservation.java
+++ b/src/main/java/net/catsnap/domain/reservation/entity/Reservation.java
@@ -1,10 +1,5 @@
 package net.catsnap.domain.reservation.entity;
 
-import net.catsnap.domain.member.entity.Member;
-import net.catsnap.domain.notification.entity.ReservationNotification;
-import net.catsnap.domain.photographer.entity.Photographer;
-import net.catsnap.domain.review.entity.Review;
-import net.catsnap.global.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -24,6 +19,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import net.catsnap.domain.member.entity.Member;
+import net.catsnap.domain.notification.entity.ReservationNotification;
+import net.catsnap.domain.photographer.entity.Photographer;
+import net.catsnap.domain.review.entity.Review;
+import net.catsnap.global.Exception.authority.OwnershipNotFoundException;
+import net.catsnap.global.entity.BaseTimeEntity;
 import org.locationtech.jts.geom.Point;
 
 @Entity
@@ -77,5 +78,17 @@ public class Reservation extends BaseTimeEntity {
 
     public void setReservationState(ReservationState reservationState) {
         this.reservationState = reservationState;
+    }
+
+    public void checkPhotographerOwnership(Long photographerId) {
+        if (!this.photographer.getId().equals(photographerId)) {
+            throw new OwnershipNotFoundException("해당 예약은 작가의 것이 아닙니다.");
+        }
+    }
+
+    public void checkMemberOwnership(Long memberId) {
+        if (!this.member.getId().equals(memberId)) {
+            throw new OwnershipNotFoundException("해당 예약은 회원의 것이 아닙니다.");
+        }
     }
 }

--- a/src/main/java/net/catsnap/domain/reservation/service/MemberReservationService.java
+++ b/src/main/java/net/catsnap/domain/reservation/service/MemberReservationService.java
@@ -25,7 +25,6 @@ import net.catsnap.domain.reservation.entity.ReservationQueryType;
 import net.catsnap.domain.reservation.entity.ReservationState;
 import net.catsnap.domain.reservation.repository.ProgramRepository;
 import net.catsnap.domain.reservation.repository.ReservationRepository;
-import net.catsnap.global.Exception.authority.OwnershipNotFoundException;
 import net.catsnap.global.Exception.authority.ResourceNotFoundException;
 import net.catsnap.global.Exception.reservation.CanNotReserveAfterDeadline;
 import net.catsnap.global.Exception.reservation.CanNotStartTimeBeforeNow;
@@ -64,9 +63,7 @@ public class MemberReservationService {
         Program program = programRepository.findById(
                 memberReservationRequest.programId())
             .orElseThrow(() -> new NotFoundProgramException("해당 작가의 프로그램이 존재하지 않습니다."));
-        if (!program.getPhotographer().getId().equals(memberReservationRequest.photographerId())) {
-            throw new OwnershipNotFoundException("해당 작가의 프로그램이 아닙니다.");
-        }
+        program.checkOwnership(memberReservationRequest.photographerId());
         if (program.getDeleted()) {
             throw new DeletedProgramException("해당 작가의 프로그램이 삭제되었습니다.");
         }

--- a/src/main/java/net/catsnap/domain/reservation/service/PhotographerReservationService.java
+++ b/src/main/java/net/catsnap/domain/reservation/service/PhotographerReservationService.java
@@ -17,7 +17,6 @@ import net.catsnap.domain.reservation.entity.WeekdayReservationTimeMapping;
 import net.catsnap.domain.reservation.repository.ReservationRepository;
 import net.catsnap.domain.reservation.repository.ReservationTimeFormatRepository;
 import net.catsnap.domain.reservation.repository.WeekdayReservationTimeMappingRepository;
-import net.catsnap.global.Exception.authority.OwnershipNotFoundException;
 import net.catsnap.global.Exception.authority.ResourceNotFoundException;
 import net.catsnap.global.Exception.reservation.CanNotChangeReservationState;
 import net.catsnap.global.security.contextholder.GetAuthenticationInfo;
@@ -94,9 +93,8 @@ public class PhotographerReservationService {
         Long photographerId = GetAuthenticationInfo.getUserId();
         reservationRepository.findById(reservationId)
             .ifPresentOrElse(reservation -> {
-                if (reservation.getPhotographer().getId().equals(photographerId)) {
-                    throw new OwnershipNotFoundException("내가 소유한 예약 중, 해당 예약을 찾을 수 없습니다.");
-                } else if (isPossibleChangeReservationState(reservation, reservationState)) {
+                reservation.checkPhotographerOwnership(photographerId);
+                if (isPossibleChangeReservationState(reservation, reservationState)) {
                     reservation.setReservationState(reservationState);
                 } else {
                     throw new CanNotChangeReservationState("예약 상태를 변경할 수 없습니다.");

--- a/src/main/java/net/catsnap/domain/reservation/service/ProgramService.java
+++ b/src/main/java/net/catsnap/domain/reservation/service/ProgramService.java
@@ -11,7 +11,6 @@ import net.catsnap.domain.reservation.dto.photographer.request.ProgramRequest;
 import net.catsnap.domain.reservation.dto.photographer.response.photographerProgramIdResponse;
 import net.catsnap.domain.reservation.entity.Program;
 import net.catsnap.domain.reservation.repository.ProgramRepository;
-import net.catsnap.global.Exception.authority.OwnershipNotFoundException;
 import net.catsnap.global.Exception.authority.ResourceNotFoundException;
 import net.catsnap.global.security.contextholder.GetAuthenticationInfo;
 import org.springframework.stereotype.Service;
@@ -54,11 +53,8 @@ public class ProgramService {
         Long photographerId = GetAuthenticationInfo.getUserId();
         programRepository.findById(programId).ifPresentOrElse(
             p -> {
-                if (p.getPhotographer().getId().equals(photographerId)) {
-                    p.softDelete();
-                } else {
-                    throw new OwnershipNotFoundException("내가 소유한 프로그램 중, 해당 프로그램을 찾을 수 없습니다.");
-                }
+                p.checkOwnership(photographerId);
+                p.softDelete();
             }, () -> {
                 throw new ResourceNotFoundException("해당 프로그램을 찾을 수 없습니다.");
             });

--- a/src/main/java/net/catsnap/domain/reservation/service/ReservationTimeService.java
+++ b/src/main/java/net/catsnap/domain/reservation/service/ReservationTimeService.java
@@ -1,5 +1,15 @@
 package net.catsnap.domain.reservation.service;
 
+import com.mongodb.client.result.DeleteResult;
+import com.mongodb.client.result.UpdateResult;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
 import net.catsnap.domain.photographer.entity.Photographer;
 import net.catsnap.domain.photographer.repository.PhotographerRepository;
 import net.catsnap.domain.reservation.document.ReservationTimeFormat;
@@ -16,17 +26,8 @@ import net.catsnap.domain.reservation.repository.ReservationRepository;
 import net.catsnap.domain.reservation.repository.ReservationTimeFormatRepository;
 import net.catsnap.domain.reservation.repository.WeekdayReservationTimeMappingRepository;
 import net.catsnap.global.Exception.authority.OwnershipNotFoundException;
+import net.catsnap.global.Exception.authority.ResourceNotFoundException;
 import net.catsnap.global.security.contextholder.GetAuthenticationInfo;
-import com.mongodb.client.result.DeleteResult;
-import com.mongodb.client.result.UpdateResult;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -46,7 +47,7 @@ public class ReservationTimeService {
         Weekday weekday = weekdayService.getWeekday(date);
         String ReservationTimeFormatId = weekdayReservationTimeMappingRepository.findByPhotographerIdAndWeekday(
                 photographerId, weekday)
-            .orElseThrow(() -> new OwnershipNotFoundException("해당 작가의 해당 요일에 예약 시간 설정이 존재하지 않습니다."))
+            .orElseThrow(() -> new ResourceNotFoundException("해당 작가의 해당 요일에 예약 시간 설정이 존재하지 않습니다."))
             .getReservationTimeFormatId();
         ReservationTimeFormat reservationTimeFormat = reservationTimeFormatRepository.findById(
             ReservationTimeFormatId);

--- a/src/main/java/net/catsnap/domain/reservation/service/ReservationTimeService.java
+++ b/src/main/java/net/catsnap/domain/reservation/service/ReservationTimeService.java
@@ -8,7 +8,6 @@ import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import net.catsnap.domain.photographer.entity.Photographer;
 import net.catsnap.domain.photographer.repository.PhotographerRepository;
@@ -148,21 +147,37 @@ public class ReservationTimeService {
     public void mappingWeekdayToReservationTimeFormat(String reservationTimeFormatId,
         Weekday weekday) {
         Long photographerId = GetAuthenticationInfo.getUserId();
-        Optional<WeekdayReservationTimeMapping> weekdayReservationTimeMapping = weekdayReservationTimeMappingRepository.findByPhotographerIdAndWeekday(
-            photographerId, weekday);
-        weekdayReservationTimeMapping.ifPresentOrElse(mapping ->
-                mapping.updateReservationTimeFormatId(reservationTimeFormatId),
-            () -> new OwnershipNotFoundException("내가 소유한 요일 중, 해당 요일을 찾을 수 없습니다.")
-        );
+        weekdayReservationTimeMappingRepository.findByPhotographerIdAndWeekday(photographerId,
+                weekday)
+            .ifPresentOrElse(mapping ->
+                    mapping.updateReservationTimeFormatId(reservationTimeFormatId),
+                () -> {
+                    weekdayReservationTimeMappingRepository.save(
+                        WeekdayReservationTimeMapping.builder()
+                            .photographer(photographerRepository.getReferenceById(photographerId))
+                            .weekday(weekday)
+                            .reservationTimeFormatId(reservationTimeFormatId)
+                            .build()
+                    );
+                }
+            );
     }
 
     public void unmappingWeekdayToReservationTimeFormatByWeekday(Weekday weekday) {
         Long photographerId = GetAuthenticationInfo.getUserId();
-        Optional<WeekdayReservationTimeMapping> weekdayReservationTimeMapping = weekdayReservationTimeMappingRepository.findByPhotographerIdAndWeekday(
-            photographerId, weekday);
-        weekdayReservationTimeMapping.ifPresentOrElse(mapping ->
-                mapping.updateReservationTimeFormatId(null),
-            () -> new OwnershipNotFoundException("내가 소유한 요일 중, 해당 요일을 찾을 수 없습니다.")
-        );
+        weekdayReservationTimeMappingRepository.findByPhotographerIdAndWeekday(photographerId,
+                weekday)
+            .ifPresentOrElse(mapping ->
+                    mapping.updateReservationTimeFormatId(null),
+                () -> {
+                    weekdayReservationTimeMappingRepository.save(
+                        WeekdayReservationTimeMapping.builder()
+                            .photographer(photographerRepository.getReferenceById(photographerId))
+                            .weekday(weekday)
+                            .reservationTimeFormatId(null)
+                            .build()
+                    );
+                }
+            );
     }
 }

--- a/src/main/java/net/catsnap/domain/review/service/ReviewService.java
+++ b/src/main/java/net/catsnap/domain/review/service/ReviewService.java
@@ -19,7 +19,6 @@ import net.catsnap.domain.review.repository.ReviewLikeRepository;
 import net.catsnap.domain.review.repository.ReviewPhotoRepository;
 import net.catsnap.domain.review.repository.ReviewRepository;
 import net.catsnap.domain.search.dto.response.ReviewSearchResponse;
-import net.catsnap.global.Exception.authority.OwnershipNotFoundException;
 import net.catsnap.global.Exception.authority.ResourceNotFoundException;
 import net.catsnap.global.aws.s3.ImageClient;
 import net.catsnap.global.aws.s3.dto.PresignedUrlResponse;
@@ -50,10 +49,7 @@ public class ReviewService {
                 postReviewRequest.reservationId()
             )
             .orElseThrow(() -> new ResourceNotFoundException("예약 정보를 찾을 수 없습니다."));
-        if (!reservation.getMember().getId().equals(memberId)) {
-            throw new OwnershipNotFoundException("예약 정보를 찾을 수 없습니다.");
-        }
-
+        reservation.checkMemberOwnership(memberId);
         Review review = postReviewRequest.toReviewEntity(reservation.getMember(),
             reservation.getPhotographer(),
             reservation);


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[feat]: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #83 

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->
리팩토링 전에는 소유권 확인을 서비스단에서 수행했다.
![image](https://github.com/user-attachments/assets/be049a7c-7c2e-43af-a71d-572f830080fe)

리팩토링 후, 소유권 확인 로직은 엔티티에서 수행하고, 필요할 때마다 해당 함수를 호출한다.
![image](https://github.com/user-attachments/assets/c601cdee-d626-45ba-b8d0-76b3633c0193)
![image](https://github.com/user-attachments/assets/e4eefeb2-2f90-4b72-86ff-379ceb263fde)

