### PR TITLE
[FIX] 로그에서 requestBody가 null로 표시되는 버그 수정 (#85)

### DIFF
--- a/src/main/java/net/catsnap/global/filter/FilterConfig.java
+++ b/src/main/java/net/catsnap/global/filter/FilterConfig.java
@@ -1,0 +1,20 @@
+package net.catsnap.global.filter;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.boot.web.servlet.filter.OrderedFilter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FilterConfig {
+
+    @Bean
+    public FilterRegistrationBean<RequestWrappingFilter> requestWrappingFilter() {
+        FilterRegistrationBean<RequestWrappingFilter> registrationBean = new FilterRegistrationBean<>();
+        registrationBean.setFilter(new RequestWrappingFilter());
+        // OrderedFilter.REQUEST_WRAPPER_FILTER_MAX_ORDER-100은 FilterChainProxy의 Order입니다.
+        // 따라서 FilterChainProxy 이전에 실행되도록 이보다 1낮은 값으로 설정합니다.
+        registrationBean.setOrder(OrderedFilter.REQUEST_WRAPPER_FILTER_MAX_ORDER - 101);
+        return registrationBean;
+    }
+}

--- a/src/main/java/net/catsnap/global/filter/RequestWrappingFilter.java
+++ b/src/main/java/net/catsnap/global/filter/RequestWrappingFilter.java
@@ -1,0 +1,23 @@
+package net.catsnap.global.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+@Component
+public class RequestWrappingFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+        FilterChain filterChain) throws ServletException, IOException {
+
+        ContentCachingRequestWrapper wrappingRequest = new ContentCachingRequestWrapper(request);
+
+        filterChain.doFilter(wrappingRequest, response);
+    }
+}

--- a/src/main/java/net/catsnap/global/filter/RequestWrappingFilter.java
+++ b/src/main/java/net/catsnap/global/filter/RequestWrappingFilter.java
@@ -5,11 +5,9 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.util.ContentCachingRequestWrapper;
 
-@Component
 public class RequestWrappingFilter extends OncePerRequestFilter {
 
     @Override


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[feat]: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #85

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->
컨트롤러에서 @RequestBody로 읽은 바디는 다시 읽을 수 없다. 
따라서 필터에 ContentCachingRequestWrapper로 request를 감싸는 로직을 추가하고
로그에서 requestBody를 다시 읽을 때에 캐시에서 읽도록 수정했다.

## 📒 requestbody를 읽으면 다시 읽을 수 없는 이유
HttpRequest의 body를 Java객체로 매핑하는 것은 DispatcherServlet에서 핸들러 어댑터를 호출할 때 발생한다.(즉, 핸들러 호출 전에 발생)

아래 코드는 핸들러(컨트롤러)에 전달될 파라미터를 하니씩 바인딩 하는 코드입니다. (ServletInvocableHandlerMethod클래스의 getMethodArgumentValues()함수)
![image](https://github.com/user-attachments/assets/7fbb9214-dd55-4d65-97f1-f51630ce168e)

@ResponseBody는 RequestResponseBodyMethodProcessor 클래스가 바인딩을 수행합니다.
![image](https://github.com/user-attachments/assets/b09c0810-cbf5-4721-ba56-035d1cefe8e4)

이때, 바인딩 하기 위해 바디의 값을 읽을 때, Stream형식으로 읽는 것을 볼 수 있습니다. (이후, 객체로 바인딩 하기 위해 objectMapper를 거칩니다.)
![image](https://github.com/user-attachments/assets/010b9d74-a5fc-4dbd-9d7b-c4068e3b21ea)

따라서 한번 읽은 HttpRequest의 body는 다시 읽을 수 없는 형태가 됩니다.

## 📒 ContentCachingRequestWrapper가 캐싱을 하는 원리
requestBody를 다시 읽기 위해서는 한번 읽은 내용을 캐싱해야 합니다. 이는 request를 스프링의 ContentCachingRequestWrapper 클래스로 한번 감싸면 간단하게 수행할 수 있습니다. 
![image](https://github.com/user-attachments/assets/be35e31e-e609-4304-995a-f2335d10f43c)

ContentCachingRequestWrapper 클래스는 InputStream을 얻을 때, 아래와 같이 오버라이드를 통해 ContentCachingInputStream(ContentCachingRequestWrapper의 내부 클래스)을 반환한니다. 
![image](https://github.com/user-attachments/assets/c24c2a12-fd7f-4e4d-a996-e0c547f1c02d)

ContentCachingInputStream는 read()함수를 통해 데이터를 읽을 때, 캐싱을 한 후, 값을 반환합니다.
![image](https://github.com/user-attachments/assets/9ef8fff9-2c62-4005-b7b9-00a4f6f98412)
![image](https://github.com/user-attachments/assets/01b96fe2-f44a-4e7f-90f7-2a288804aeb0)

ContentCachingRequestWrapper클래스의 맴버 변수 cachedContent에 저장하는 것을 알 수 있습니다.cachedContent
![image](https://github.com/user-attachments/assets/ebeb9123-1058-43a3-8962-95058ec7a554)

캐싱된 데이터는 getContentAsByteArray()함수를 통해 가져올 수 있습니다.
![image](https://github.com/user-attachments/assets/0e11f1d9-70da-4e54-be9e-c334646b1151)

## 📒 DelegatingFilterProxy의 필터 우선순위
DelegatingFilterProxy는 스프링 시큐리티 필터 체인을 시작점입니다. 시큐리티 필터는 서블릿 필터에 등록되는 것이 아니라 시큐리티 필터 체인에 등록이 되고, DelegatingFilterProxy만이 서블릿 필터에 등록됩니다.
![image](https://github.com/user-attachments/assets/661bbc4a-ccb1-4aed-81b1-3fc66efac04e)
(출처 : https://docs.spring.io/spring-security/reference/servlet/architecture.html)

그런데 DelegatingFilterProxy 순서가 ContentCachingRequestWrapper보다 늦게 오길 원했습니다.
그리고 SecurityProperties에서 DelegatingFilterProxy의 Order가 -100인것을 확인했습니다(OrderedFilter.REQUEST_WRAPPER_FILTER_MAX_ORDER는 0)
![image](https://github.com/user-attachments/assets/dfbfd6a0-bafd-48e1-a7aa-861dcde0a264)

따라서 ContentCachingRequestWrapper 필터의 우선순위를 아래와 같이 지정했습니다.
![image](https://github.com/user-attachments/assets/8fc5bfac-d59d-4942-93e4-20f87e196e89)


