### PR TITLE
[FIX] 동시에 같은 예약을 할 때, 두 예약 모두가 성공하는 버그 수정 (#87)

### DIFF
--- a/src/main/java/net/catsnap/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/net/catsnap/domain/reservation/repository/ReservationRepository.java
@@ -1,13 +1,15 @@
 package net.catsnap.domain.reservation.repository;
 
-import net.catsnap.domain.reservation.entity.Reservation;
-import net.catsnap.domain.reservation.entity.ReservationState;
 import java.time.LocalDateTime;
 import java.util.List;
+import net.catsnap.domain.reservation.entity.Reservation;
+import net.catsnap.domain.reservation.entity.ReservationState;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
 
@@ -35,4 +37,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
         "program"}, type = EntityGraph.EntityGraphType.FETCH)
     List<Reservation> findAllReservationWithEagerByMemberIdAndStartTimeBetween(Long memberId,
         LocalDateTime startTime, LocalDateTime endTime);
+
+    @Query(value = "SELECT pg_advisory_xact_lock(:photographerId)", nativeQuery = true)
+    void acquireReservationLock(@Param("photographerId") Long photographerId);
 }

--- a/src/main/java/net/catsnap/domain/reservation/service/MemberReservationService.java
+++ b/src/main/java/net/catsnap/domain/reservation/service/MemberReservationService.java
@@ -68,6 +68,8 @@ public class MemberReservationService {
             throw new DeletedProgramException("해당 작가의 프로그램이 삭제되었습니다.");
         }
 
+        reservationRepository.acquireReservationLock(memberReservationRequest.photographerId());
+        
         /*
          * 1. 해당 작가가 해당 일에 예약을 받을 수 있게 했는지 확인
          * 2. 예약 시작 시간이 현재 시간보다 이후인지 확인


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[feat]: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #87 

## ✨ PR 세부 내용
동시에 같은 예약을 할 때, 데이터베이스 Lock을 통해 얻은 후에 예약하도록 수정했습니다.

## 📒 예약 서비스의 로직
Catsnap에서는 작가가 유연하게 자신의 예약을 설정하기 위해, 1개의 예약이 1개의 row를 차지합니다.
![image](https://github.com/user-attachments/assets/7b004ee7-c600-4d94-aa18-6ddc951b3545)

새로운 예약 요청이 들어오면, 해당 시간에 예약이 가능한가를 확인합니다. 
특정 작가의 특정 일에 아래와 같이 예약이 있다고 가정해봅시다.
![image](https://github.com/user-attachments/assets/0dfcc0a3-edf6-451a-b056-e1996a950067)

새로운 예약이 기존의 예약과 겹치지 않는다면, 새로운 예약을 수락합니다.
![image](https://github.com/user-attachments/assets/c61c8d62-5b59-4752-b229-094b2cc89522)

그러나 아래와 같이 기존 예약과 겹치는 시간이 있다면, 새로운 예약을 거절하게 됩니다.
![image](https://github.com/user-attachments/assets/30db93b6-a588-494c-9fc8-e727f6f78cd9)

만약 동시에 같은 예약이 들어온다면 두 예약 중, 하나를 거절해야 합니다.
![image](https://github.com/user-attachments/assets/ce4b1098-94ab-4700-807d-68ec032054cc)

그러나 현재 코드에서는 두 예약 모두 예약이 가능했습니다. 이는 중복되는 예약을 확인할 때, 서로 다른 트랜잭션에 속한 새로운 예약은 조회가 되지 않기 때문입니다. 
따라서 적절한 동시성 처리를 해야했습니다.


##  📒 PostgreSQL의 isolation level
예약의 동시성 문제를 해결하기 위해, PostgreSQL이 제공하는 isolation level을 알아보았습니다.
PostgreSQL이 제공하는 isolation level은 아래와 같습니다.
![image](https://github.com/user-attachments/assets/8e287bd5-0ab3-4d62-9561-dd35082418de)
(출처 : https://www.postgresql.org/docs/current/transaction-iso.html)

예약 1개가 1개의 row에 해당했기 때문에 적어도, Phantom Read를 허용하지 않는 레벨인 Repeatable read 이상의 레벨을 사용해야 한다고 생각했습니다. (ANSI SQL 표준에서는 Repeatable read레벨에서 Phantom Read를 허용하지만, PostgreSQL에서는 Phantom Read를 허용하지 않습니다)

**1. Repeatable read level을 사용했을 때**
결론적으로, 중복 예약을 막지 못했습니다. 
Phantom Read를 방지하기 위해, 데이터베이스는 트랜잭션이 시작할 때의 기준으로 쿼리에 대한 응답을 줍니다. 그런데 동시에 같은 예약 생성 요청이 들어오면, 두 트랜잭션 모두 해당 시간에 예약이 없기 때문에 두 예약 모두 성공을 하게됩니다. 이는 우리가 원하는 결과가 아니므로 다른 해결책을 찾아야 합니다.

**2. Serializable level을 사용했을 때**
결론적으로, 중복예약을 막을 수 있었지만, 과도하고 불편하게(?) 막습니다.
Serializable level은 데이터베이스가 제공하는 가장 엄격한 격리 수준입니다. Serializable level 트랜잭션을 사용하게 되면, 동시요청 중, 더 빨리 도착한 예약을 수락하고, 나중에 들어온 요청은 예외를 발생시킵니다.
하지만, 예약이 중복되어서 발생하는 비즈니즈 예외가 아닌, 데이터베이스가 발생시키는 예외(CannotAcquireLockException)를 던집니다. 
![image](https://github.com/user-attachments/assets/b47b3271-a986-43ce-a1b4-7d1849d27886)

이는 Serializable level은 직렬성을 보장해야 하기 때문에 서로 다른 트랜잭션이 영향을 주게 되면(두 트랜잭션의 순서를 바꾸면 결과가 달라지면) 트랜잭션을 롤백시키기 때문입니다. 예약 생성 트랜잭션에서, 기존 예약을 조회하는 쿼리가 두 트랜잭션 순서에 영향을 받기 때문에 예외를 발생시키며 롤백되었습니다.  

또한 해당 레벨은  동시에 들어왔으나, 시간이 겹치지 않는 예약도 예외를 발생시킨다는 문제를 가지고 있습니다. 만약 10시 예약과 12시 예약이 동시에 들어온다면 이는 겹치지 않는 예약이기 때문에 두 요청 모두 예외가 발생하면 안됩니다. 그러나 Serializable level은 이런 비즈니스 적인 관점이 아닌, 두 트랜잭션이 충돌 하기 때문에(기존 예약 조회 쿼리의 영향을 받음)  예외를 발생시킵니다.

따라서 이 모든 문제를 해결하기 위해서는 CannotAcquireLockException을 try-catch로 받고, 예외 메시지가 힌트(Hint: The transaction might succeed if retried.)를 준 것처럼 몇번 더 반복을 하면 해결할 수 있습니다. 그러나 더 깔끔하게 동시성을 처리할 수 있다면 다른 방법을 사용해야 합니다.

##  📒 PostgreSQL의 Row-Level Locks
PostgreSQL는 4가지 수준의 Row-Level Locks을 제공합니다.
![image](https://github.com/user-attachments/assets/0cac5893-ec24-461c-979d-6ad36eaf6a37)
(출처 : https://www.postgresql.org/docs/current/explicit-locking.html)
그러나 Row-Level Locks은 이미 존재하는 행에 대해 Lock을 걸 수 있습니다. 즉, 우리는 "해당 구간에는 예약이 들어올 수 있으니 일단 해당 구간에 예약을 잡지 마" 같은 Lock을 걸 수 없습니다. 따라서 Row-Level Lock을 사용하기 어렵습니다.

##  📒 PostgreSQL의 Advisory Locks
PostgresSQL은 application-defined의 Lock을 제공합니다. 즉, 트랜잭션 isolation level과 Row-Level Locks을 통해 원하는 결과를 얻지 못했을 때 사용할 수 있도록 만든 lock입니다. 
![image](https://github.com/user-attachments/assets/f6b18d8b-ad32-4c81-a21e-d2dd4143202d)
(출처 : https://www.postgresql.org/docs/current/explicit-locking.html)

따라서 예약을 할 때, 작가의 데이터베이스 id롤 통해 lock을 얻고 예약이 끝나면(트랜잭션이 끝나면) lock을 release하는 방식으로 구현을 했습니다.

Advisory Locks의 크게 세션 레벨과 트랜잭션 레벨이 있는데, 세션 레벨은 명시적으로 lock을 release해야 하고, 트랜잭션은 트랜잭션이 끝나면 자동 relelase를 하기 때문에 트랜잭션 레벨을 선택했습니다.
(출처 : https://www.postgresql.org/docs/current/functions-admin.html)

