### PR TITLE
[FIX] 로그에서 RequestBody가 항상 null로 찍히는 버그 수정 (#91)

### DIFF
--- a/src/main/java/net/catsnap/global/filter/FilterConfig.java
+++ b/src/main/java/net/catsnap/global/filter/FilterConfig.java
@@ -13,8 +13,8 @@ public class FilterConfig {
         FilterRegistrationBean<RequestWrappingFilter> registrationBean = new FilterRegistrationBean<>();
         registrationBean.setFilter(new RequestWrappingFilter());
         // OrderedFilter.REQUEST_WRAPPER_FILTER_MAX_ORDER-100은 FilterChainProxy의 Order입니다.
-        // 따라서 FilterChainProxy 이전에 실행되도록 이보다 1낮은 값으로 설정합니다.
-        registrationBean.setOrder(OrderedFilter.REQUEST_WRAPPER_FILTER_MAX_ORDER - 101);
+        // FilterChainProxy가 나중에 실행되도록 설정합니다.
+        registrationBean.setOrder(OrderedFilter.REQUEST_WRAPPER_FILTER_MAX_ORDER - 99);
         return registrationBean;
     }
 }

--- a/src/main/java/net/catsnap/global/filter/FilterConfig.java
+++ b/src/main/java/net/catsnap/global/filter/FilterConfig.java
@@ -1,7 +1,6 @@
 package net.catsnap.global.filter;
 
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
-import org.springframework.boot.web.servlet.filter.OrderedFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -12,9 +11,9 @@ public class FilterConfig {
     public FilterRegistrationBean<RequestWrappingFilter> requestWrappingFilter() {
         FilterRegistrationBean<RequestWrappingFilter> registrationBean = new FilterRegistrationBean<>();
         registrationBean.setFilter(new RequestWrappingFilter());
-        // OrderedFilter.REQUEST_WRAPPER_FILTER_MAX_ORDER-100은 FilterChainProxy의 Order입니다.
+        // OrderedFilter.REQUEST_WRAPPER_FILTER_MAX_ORDER-100 (-100)은 FilterChainProxy의 Order입니다.
         // FilterChainProxy가 나중에 실행되도록 설정합니다.
-        registrationBean.setOrder(OrderedFilter.REQUEST_WRAPPER_FILTER_MAX_ORDER - 99);
+        registrationBean.setOrder(1000000);
         return registrationBean;
     }
 }

--- a/src/main/java/net/catsnap/global/security/SecurityConfig.java
+++ b/src/main/java/net/catsnap/global/security/SecurityConfig.java
@@ -90,19 +90,6 @@ public class SecurityConfig {
     }
 
     @Bean
-    public MemberSignInAuthenticationFilter memberSignInAuthenticationFilter() throws Exception {
-        return new MemberSignInAuthenticationFilter(authenticationManager(), objectMapper,
-            servletSecurityResponse);
-    }
-
-    @Bean
-    public PhotographerSignInAuthenticationFilter photographerSignInAuthenticationFilter()
-        throws Exception {
-        return new PhotographerSignInAuthenticationFilter(authenticationManager(), objectMapper,
-            servletSecurityResponse);
-    }
-
-    @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOrigins(


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[feat]: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #91 

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->
HttpRequest의 body는 스트림으로 읽기 때문에 한번 읽게 되면 다시 읽을 수 없어, body를 읽을 때 캐싱을 하는 필터를 추가하였다(#86).
이때 스프링 시큐리티 필터가 바디를 읽을 수도 있으니 DelegatingFilterProxy 앞에 캐싱 필터를 추가하였다.

그러나 스프링 시큐리티 필터에 기본적으로 추가되는 필터 중에서 HttpRequest를 감싸서 다음 필터로 넘기는 필터들이 있었다.
해당 필터는 @EnableWebSecurity(debug = true)을 통해 볼 수 있다.
![image](https://github.com/user-attachments/assets/fa4945e4-8f72-47cb-8c5c-c5a8fe8dbfb9)

여기서 request를 한번 감싸는 필터는 2가지이다.
1. RequestCacheAwareFilter
![image](https://github.com/user-attachments/assets/37327c5f-42ef-465f-9479-2d225b09c248)

2. SecurityContextHolderAwareRequestFilter
![image](https://github.com/user-attachments/assets/a4ee0912-17a6-4d56-84e9-12f4d15bfd67)

따라서 시큐리티 필터 전에 ContentCachingRequestWrapper로 request를 감싸면 해당 필터들이 한번 더 감싸게 되어 캐싱된 값을 확인할 때 캐스팅이 한번에 되지 않는다.
request가 ContentCachingRequestWrapper로 캐싱되지 않는다면 Wrapper로 벗겨낸 후, 다시 캐스팅을 해야 한다.

결국 캐싱 필터를 시큐리티 필터 뒤에 위치시켜 편하게 캐스팅하느냐, 아니면 캐싱 필터를 시큐리티 필터 앞에 위치시켜 더 안전하게 캐싱을 수행하느냐를 선택해야 했다.

결론적으로 전자를 선택했다.
왜냐하면, 현재 필터에서 바디를 읽는 경우는 로그인 할 때 아이디와 비밀번호를 읽을 때 뿐이다.. 그런데 이 정보들을 캐싱해서 가지고 있는 것이 부담스러웠다. 또한 이 경우가 아니라면 바디는 컨트롤러에서 읽히기 때문에 굳이 캐스팅 가능한지 확인해 가며 읽는 것보다 컨트롤러 앞에 캐싱 필터를  위치시키는게 더 간편했다.

참고) 
서블릿 필터를 포함한 모든 필터를 출력하는 방법
![image](https://github.com/user-attachments/assets/00a0a2bf-3219-4935-a699-ceddc572860b)

![image](https://github.com/user-attachments/assets/72fbf51e-64fc-44ba-860a-c081ecd03487)



