### PR TITLE
[FIX] API 조회시 시간 형식 추가 (#99)

### DIFF
--- a/src/main/java/net/catsnap/domain/reservation/dto/member/response/MemberReservationInformationResponse.java
+++ b/src/main/java/net/catsnap/domain/reservation/dto/member/response/MemberReservationInformationResponse.java
@@ -1,17 +1,19 @@
 package net.catsnap.domain.reservation.dto.member.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
 import net.catsnap.domain.photographer.dto.response.PhotographerTinyInformationResponse;
 import net.catsnap.domain.reservation.dto.ReservationLocation;
 import net.catsnap.domain.reservation.dto.ReservedProgramResponse;
 import net.catsnap.domain.reservation.entity.Reservation;
 import net.catsnap.domain.reservation.entity.ReservationState;
-import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDateTime;
 
 public record MemberReservationInformationResponse(
     Long reservationId,
     PhotographerTinyInformationResponse photographerTinyInformationResponse,
     ReservationLocation reservationLocation,
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
     LocalDateTime startTime,
     ReservedProgramResponse reservedProgramResponse,
     @Schema(description = "예약의 상태를 나타냅니다.", nullable = false, example = "PENDING, APPROVED, REJECTED, MEMBER_CANCELLED, PHOTOGRAPHY_CANCELLED 중 한개의 값")


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[feat]: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #99 

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->
api응답시 LocatDateTime에 JsonFormat에노테이션을 통해 적절하게 시간 형식을 맞추었습니다.
