### PR TITLE
[FIX] 예약 가능한 시간 조회 시, 중복되지 않는 시간 계산하는 알고리즘 수정 (#101)

### DIFF
--- a/src/main/java/net/catsnap/domain/reservation/service/ReservationTimeService.java
+++ b/src/main/java/net/catsnap/domain/reservation/service/ReservationTimeService.java
@@ -68,22 +68,20 @@ public class ReservationTimeService {
             LocalDateTime.of(date, LocalTime.MAX));
 
         List<PhotographerAvailableReservationTimeResponse> photographerAvailableReservationTimeResponseArrayList = new ArrayList<>();
+
         for (LocalTime startTime : photographerStartTimeList) {
             boolean isAvailableReservation = true;
-            LocalDateTime startDateTime = LocalDateTime.now().toLocalDate().atTime(startTime);
             for (Reservation reservation : reservationList) {
-                LocalDateTime reservationStartTime = reservation.getStartTime();
-                LocalDateTime reservationEndTime = reservation.getEndTime();
-                if (reservationStartTime.isAfter(startDateTime)
-                    || reservationStartTime.isEqual(startDateTime)
-                    && reservationEndTime.isBefore(startDateTime) || reservationEndTime.isEqual(
-                    startDateTime)) {
+                if (reservation.getStartTime().toLocalTime().equals(startTime)
+                    || reservation.getEndTime().toLocalTime().isAfter(startTime)
+                    && reservation.getStartTime().toLocalTime().isBefore(startTime)) {
                     isAvailableReservation = false;
                     break;
                 }
             }
             photographerAvailableReservationTimeResponseArrayList.add(
-                PhotographerAvailableReservationTimeResponse.of(startTime, isAvailableReservation));
+                PhotographerAvailableReservationTimeResponse.of(startTime, isAvailableReservation)
+            );
         }
 
         return PhotographerAvailableReservationTimeListResponse.from(


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[feat]: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #101 

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->
예약 가능한 시간 조회 시, 중복되지 않는 시간 계산하는 알고리즘 수정했습니다.
