### PR TITLE
[FEAT] 로그인 하지 않은 사용자를 의미하는 데이터 추가 (#114)

### DIFF
--- a/src/main/java/net/catsnap/domain/user/entity/User.java
+++ b/src/main/java/net/catsnap/domain/user/entity/User.java
@@ -16,6 +16,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.DiscriminatorOptions;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.security.core.GrantedAuthority;
@@ -23,6 +24,7 @@ import org.springframework.security.core.GrantedAuthority;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @DiscriminatorColumn
+@DiscriminatorOptions(force = false)
 @Table(name = "users")
 @Getter
 @SuperBuilder

--- a/src/main/java/net/catsnap/domain/user/fakeuser/entity/FakeUser.java
+++ b/src/main/java/net/catsnap/domain/user/fakeuser/entity/FakeUser.java
@@ -4,7 +4,6 @@ import java.util.Collection;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import net.catsnap.domain.user.entity.User;
 import net.catsnap.global.security.authority.CatsnapAuthority;
@@ -13,8 +12,10 @@ import org.springframework.security.core.GrantedAuthority;
 @Getter
 @SuperBuilder
 @AllArgsConstructor
-@NoArgsConstructor
 public class FakeUser extends User {
+
+    public static Long fakeUserId = -1L;
+    public static String fakeUserIdentifier = "anonymous";
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/src/main/java/net/catsnap/domain/user/fakeuser/entity/FakeUser.java
+++ b/src/main/java/net/catsnap/domain/user/fakeuser/entity/FakeUser.java
@@ -1,0 +1,23 @@
+package net.catsnap.domain.user.fakeuser.entity;
+
+import java.util.Collection;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import net.catsnap.domain.user.entity.User;
+import net.catsnap.global.security.authority.CatsnapAuthority;
+import org.springframework.security.core.GrantedAuthority;
+
+@Getter
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
+public class FakeUser extends User {
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(CatsnapAuthority.ANONYMOUS);
+    }
+}

--- a/src/main/java/net/catsnap/global/security/SecurityConfig.java
+++ b/src/main/java/net/catsnap/global/security/SecurityConfig.java
@@ -8,7 +8,6 @@ import java.util.List;
 import javax.crypto.SecretKey;
 import lombok.RequiredArgsConstructor;
 import net.catsnap.domain.user.repository.UserRepository;
-import net.catsnap.global.security.authority.CatsnapAuthority;
 import net.catsnap.global.security.filter.JwtAuthenticationFilter;
 import net.catsnap.global.security.filter.RefreshAccessTokenFilter;
 import net.catsnap.global.security.filter.SignInAuthenticationFilter;
@@ -124,11 +123,6 @@ public class SecurityConfig {
             .authorizeHttpRequests(authorizeRequests ->
                 authorizeRequests
                     .anyRequest().permitAll()
-            )
-            .anonymous(
-                anonymousConfigurer -> anonymousConfigurer
-                    .principal("anonymous")
-                    .authorities(List.of(CatsnapAuthority.ANONYMOUS))
             );
         return http.build();
     }

--- a/src/main/java/net/catsnap/global/security/authenticationToken/AnonymousAuthenticationToken.java
+++ b/src/main/java/net/catsnap/global/security/authenticationToken/AnonymousAuthenticationToken.java
@@ -1,0 +1,17 @@
+package net.catsnap.global.security.authenticationToken;
+
+import java.util.Collection;
+import net.catsnap.domain.user.fakeuser.entity.FakeUser;
+import org.springframework.security.core.GrantedAuthority;
+
+public class AnonymousAuthenticationToken extends CatsnapAuthenticationToken {
+
+    public AnonymousAuthenticationToken(Object principal, Object credentials) {
+        super(principal, credentials);
+    }
+
+    public AnonymousAuthenticationToken(Object principal,
+        Collection<? extends GrantedAuthority> authorities) {
+        super(principal, FakeUser.fakeUserIdentifier, authorities, FakeUser.fakeUserId);
+    }
+}

--- a/src/main/java/net/catsnap/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/net/catsnap/global/security/filter/JwtAuthenticationFilter.java
@@ -9,11 +9,15 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import net.catsnap.global.result.errorcode.SecurityErrorCode;
+import net.catsnap.global.security.authenticationToken.AnonymousAuthenticationToken;
 import net.catsnap.global.security.authenticationToken.CatsnapAuthenticationToken;
+import net.catsnap.global.security.authority.CatsnapAuthority;
 import net.catsnap.global.security.util.ServletSecurityResponse;
 import net.catsnap.global.security.util.TokenAuthentication;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -28,6 +32,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         FilterChain filterChain) throws ServletException, IOException {
         String jwt = request.getHeader("Authorization");
         if (jwt == null) {
+            Authentication authenticationToken = new AnonymousAuthenticationToken(null,
+                List.of(CatsnapAuthority.ANONYMOUS));
+            SecurityContextHolder.getContext().setAuthentication(authenticationToken);
             filterChain.doFilter(request, response);
         } else {
             jwt = parseJwt(jwt);

--- a/src/main/resources/sql/FakeUser.sql
+++ b/src/main/resources/sql/FakeUser.sql
@@ -1,0 +1,3 @@
+INSERT INTO users (id, dtype, birthday, created_at, identifier, nickname, password, phone_number)
+VALUES (-1, 'FakeUser', '1990-01-01', '2024-01-01 00:00:00.000000', 'fakeuser', 'fakeuser',
+        'fakeuser', '010-1234-5678')


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[feat]: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #114 

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->
리팩토링 전에는 로그인하지 않은 사용자는 데이터베이스의 id를 할당받지 못하는 상황이었습니다.

리팩토링 후 로그인하지 않은 사용자의 id를 -1로 반환하도록 하였습니다. 
또한 데이터베이스에서 Users 테이블에 id가 -1인 사용자를 삽입하는 쿼리문을 작성하였습니다.