### PR TITLE
[FEAT] 리뷰의 좋아요 엔티티가 User 엔티티에 의존하도록 변경 (#116)

### DIFF
--- a/src/main/java/net/catsnap/domain/auth/argumentresolver/UserId.java
+++ b/src/main/java/net/catsnap/domain/auth/argumentresolver/UserId.java
@@ -1,5 +1,6 @@
 package net.catsnap.domain.auth.argumentresolver;
 
+import io.swagger.v3.oas.annotations.Parameter;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -10,6 +11,7 @@ import java.lang.annotation.Target;
  */
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
+@Parameter(hidden = true) // Swagger UI에서 파라미터를 숨김
 public @interface UserId {
 
 }

--- a/src/main/java/net/catsnap/domain/review/controller/ReviewController.java
+++ b/src/main/java/net/catsnap/domain/review/controller/ReviewController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import net.catsnap.domain.auth.argumentresolver.UserId;
 import net.catsnap.domain.auth.interceptor.AnyUser;
 import net.catsnap.domain.auth.interceptor.LoginMember;
 import net.catsnap.domain.auth.interceptor.LoginUser;
@@ -55,11 +56,13 @@ public class ReviewController {
     @PostMapping("/like/{reviewId}")
     @LoginUser
     public ResponseEntity<ResultResponse<ReviewResultCode>> reviewLikeToggle(
+        @UserId
+        Long userId,
         @Parameter(description = "리뷰 id")
         @RequestParam("reviewId")
         Long reviewId
     ) {
-        reviewService.toggleReviewLike(reviewId);
+        reviewService.toggleReviewLike(reviewId, userId);
         return ResultResponse.of(ReviewResultCode.REVIEW_LIKE_TOGGLE);
     }
 
@@ -70,11 +73,13 @@ public class ReviewController {
     @GetMapping("/{reviewId}")
     @AnyUser
     public ResponseEntity<ResultResponse<ReviewSearchResponse>> getReview(
+        @UserId
+        Long userId,
         @Parameter(description = "리뷰 id")
         @PathVariable("reviewId")
         Long reviewId
     ) {
-        ReviewSearchResponse reviewSearchResponse = reviewService.getReview(reviewId);
+        ReviewSearchResponse reviewSearchResponse = reviewService.getReview(reviewId, userId);
         return ResultResponse.of(ReviewResultCode.GET_REVIEW, reviewSearchResponse);
     }
 }

--- a/src/main/java/net/catsnap/domain/review/entity/ReviewLike.java
+++ b/src/main/java/net/catsnap/domain/review/entity/ReviewLike.java
@@ -37,14 +37,8 @@ public class ReviewLike extends BaseTimeEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
-    private Boolean liked = true;
-
     public ReviewLike(Review review, User user) {
         this.review = review;
         this.user = user;
-    }
-
-    public void toggleLike() {
-        this.liked = !this.liked;
     }
 }

--- a/src/main/java/net/catsnap/domain/review/entity/ReviewLike.java
+++ b/src/main/java/net/catsnap/domain/review/entity/ReviewLike.java
@@ -13,8 +13,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import net.catsnap.domain.user.member.entity.Member;
-import net.catsnap.domain.user.photographer.entity.Photographer;
+import net.catsnap.domain.user.entity.User;
 import net.catsnap.global.entity.BaseTimeEntity;
 
 @Entity
@@ -35,29 +34,14 @@ public class ReviewLike extends BaseTimeEntity {
     private Review review;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
-    private Member member;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "photographer_id")
-    private Photographer photographer;
+    @JoinColumn(name = "user_id")
+    private User user;
 
     private Boolean liked = true;
 
-    /*
-     * 사용자가 리뷰에 좋아요를 누르는 경우
-     */
-    public ReviewLike(Review review, Member member) {
+    public ReviewLike(Review review, User user) {
         this.review = review;
-        this.member = member;
-    }
-
-    /*
-     * 작가가 리뷰에 좋아요를 누르는 경우
-     */
-    public ReviewLike(Review review, Photographer photographer) {
-        this.review = review;
-        this.photographer = photographer;
+        this.user = user;
     }
 
     public void toggleLike() {

--- a/src/main/java/net/catsnap/domain/review/repository/ReviewLikeRepository.java
+++ b/src/main/java/net/catsnap/domain/review/repository/ReviewLikeRepository.java
@@ -6,9 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReviewLikeRepository extends JpaRepository<ReviewLike, Long> {
 
-    Long countByReviewIdAndLiked(Long reviewId, Boolean liked);
+    Long countByReviewId(Long reviewId);
 
-    Optional<ReviewLike> findByReviewIdAndMemberId(Long reviewId, Long memberId);
-
-    Optional<ReviewLike> findByReviewIdAndPhotographerId(Long reviewId, Long photographerId);
+    Optional<ReviewLike> findByReviewIdAndUserId(Long reviewId, Long userId);
 }

--- a/src/main/java/net/catsnap/domain/review/service/ReviewLikeService.java
+++ b/src/main/java/net/catsnap/domain/review/service/ReviewLikeService.java
@@ -1,10 +1,7 @@
 package net.catsnap.domain.review.service;
 
 import lombok.RequiredArgsConstructor;
-import net.catsnap.domain.review.entity.ReviewLike;
 import net.catsnap.domain.review.repository.ReviewLikeRepository;
-import net.catsnap.global.security.authority.CatsnapAuthority;
-import net.catsnap.global.security.contextholder.GetAuthenticationInfo;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,24 +13,11 @@ public class ReviewLikeService {
 
     @Transactional(readOnly = true)
     Long getReviewLikeCount(Long reviewId) {
-        return reviewLikeRepository.countByReviewIdAndLiked(reviewId, true);
+        return reviewLikeRepository.countByReviewId(reviewId);
     }
 
     @Transactional(readOnly = true)
-    Boolean isMeReviewLiked(Long reviewId) {
-        CatsnapAuthority authority = GetAuthenticationInfo.getAuthority();
-        if (authority == CatsnapAuthority.MEMBER) {
-            Long id = GetAuthenticationInfo.getUserId();
-            return reviewLikeRepository.findByReviewIdAndMemberId(reviewId, id)
-                .map(ReviewLike::getLiked)
-                .orElse(false);
-        } else if (authority == CatsnapAuthority.PHOTOGRAPHER) {
-            Long id = GetAuthenticationInfo.getUserId();
-            return reviewLikeRepository.findByReviewIdAndPhotographerId(reviewId, id)
-                .map(ReviewLike::getLiked)
-                .orElse(false);
-        } else {
-            return false;
-        }
+    Boolean isMeReviewLiked(Long reviewId, Long userId) {
+        return reviewLikeRepository.findByReviewIdAndUserId(reviewId, userId).isPresent();
     }
 }

--- a/src/main/java/net/catsnap/domain/user/entity/User.java
+++ b/src/main/java/net/catsnap/domain/user/entity/User.java
@@ -8,14 +8,17 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Collection;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import net.catsnap.domain.review.entity.ReviewLike;
 import org.hibernate.annotations.DiscriminatorOptions;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -49,6 +52,10 @@ public abstract class User {
     @LastModifiedDate
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
+
+    //OneToMany
+    @OneToMany(mappedBy = "user")
+    private List<ReviewLike> reviewLikeList;
 
     public abstract Collection<? extends GrantedAuthority> getAuthorities();
 }

--- a/src/main/java/net/catsnap/domain/user/member/entity/Member.java
+++ b/src/main/java/net/catsnap/domain/user/member/entity/Member.java
@@ -17,7 +17,6 @@ import net.catsnap.domain.feed.entity.FeedLike;
 import net.catsnap.domain.notification.entity.Notification;
 import net.catsnap.domain.reservation.entity.Reservation;
 import net.catsnap.domain.review.entity.Review;
-import net.catsnap.domain.review.entity.ReviewLike;
 import net.catsnap.domain.social.entity.PhotographerBlock;
 import net.catsnap.domain.social.entity.PhotographerSubscribe;
 import net.catsnap.domain.social.entity.PlaceSubscribe;
@@ -58,9 +57,6 @@ public class Member extends User {
 
     @OneToMany(mappedBy = "member")
     private List<Review> reviewList;
-
-    @OneToMany(mappedBy = "member")
-    private List<ReviewLike> ReviewLikeList;
 
     @OneToMany(mappedBy = "member")
     private List<FeedLike> feedLikeList;

--- a/src/main/java/net/catsnap/domain/user/photographer/entity/Photographer.java
+++ b/src/main/java/net/catsnap/domain/user/photographer/entity/Photographer.java
@@ -17,7 +17,6 @@ import net.catsnap.domain.reservation.entity.Program;
 import net.catsnap.domain.reservation.entity.Reservation;
 import net.catsnap.domain.reservation.entity.WeekdayReservationTimeMapping;
 import net.catsnap.domain.review.entity.Review;
-import net.catsnap.domain.review.entity.ReviewLike;
 import net.catsnap.domain.user.entity.User;
 import net.catsnap.global.security.authority.CatsnapAuthority;
 import org.springframework.security.core.GrantedAuthority;
@@ -55,9 +54,6 @@ public class Photographer extends User {
 
     @OneToMany(mappedBy = "photographer")
     private List<Program> programList;
-
-    @OneToMany(mappedBy = "photographer")
-    private List<ReviewLike> reviewLikeList;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/src/test/java/net/catsnap/domain/review/repository/ReviewLikeRepositoryTest.java
+++ b/src/test/java/net/catsnap/domain/review/repository/ReviewLikeRepositoryTest.java
@@ -76,48 +76,24 @@ class ReviewLikeRepositoryTest {
 
         Member likedMember = MemberFixture.member()
             .build();
-        Member unLikedMember = MemberFixture.member()
-            .build();
         memberRepository.save(likedMember);
-        memberRepository.save(unLikedMember);
         ReviewLike reviewLike = ReviewLikeFixture.reviewLike()
-            .member(likedMember)
-            .photographer(null)
+            .user(likedMember)
             .review(review)
-            .liked(true)
-            .build();
-        ReviewLike reviewUnliked = ReviewLikeFixture.reviewLike()
-            .member(unLikedMember)
-            .photographer(null)
-            .review(review)
-            .liked(false)
             .build();
         reviewLikeRepository.save(reviewLike);
-        reviewLikeRepository.save(reviewUnliked);
 
         Photographer likedPhotographer = PhotographerFixture.photographer()
             .build();
-        Photographer unlikedPhotographer = PhotographerFixture.photographer()
-            .build();
         photographerRepository.save(likedPhotographer);
-        photographerRepository.save(unlikedPhotographer);
         ReviewLike reviewLike2 = ReviewLikeFixture.reviewLike()
-            .member(null)
-            .photographer(likedPhotographer)
+            .user(likedPhotographer)
             .review(review)
-            .liked(true)
-            .build();
-        ReviewLike reviewUnliked2 = ReviewLikeFixture.reviewLike()
-            .member(null)
-            .photographer(unlikedPhotographer)
-            .review(review)
-            .liked(false)
             .build();
         reviewLikeRepository.save(reviewLike2);
-        reviewLikeRepository.save(reviewUnliked2);
 
         //when
-        Long likeCount = reviewLikeRepository.countByReviewId(review.getId(), true);
+        Long likeCount = reviewLikeRepository.countByReviewId(review.getId());
 
         //then
         Assertions.assertThat(likeCount).isEqualTo(2);
@@ -158,16 +134,15 @@ class ReviewLikeRepositoryTest {
         memberRepository.save(likedMember);
         memberRepository.save(unLikedMember);
         ReviewLike reviewLike = ReviewLikeFixture.reviewLike()
-            .member(likedMember)
-            .photographer(null)
+            .user(likedMember)
             .review(review)
             .build();
         reviewLikeRepository.save(reviewLike);
 
         //when
-        Optional<ReviewLike> liked = reviewLikeRepository.findByReviewIdAndMemberId(review.getId(),
+        Optional<ReviewLike> liked = reviewLikeRepository.findByReviewIdAndUserId(review.getId(),
             likedMember.getId());
-        Optional<ReviewLike> unLiked = reviewLikeRepository.findByReviewIdAndMemberId(
+        Optional<ReviewLike> unLiked = reviewLikeRepository.findByReviewIdAndUserId(
             review.getId(),
             unLikedMember.getId());
 
@@ -210,17 +185,16 @@ class ReviewLikeRepositoryTest {
         photographerRepository.save(likedPhotographer);
         photographerRepository.save(unlikedPhotographer);
         ReviewLike reviewLike = ReviewLikeFixture.reviewLike()
-            .member(null)
-            .photographer(likedPhotographer)
+            .user(likedPhotographer)
             .review(review)
             .build();
         reviewLikeRepository.save(reviewLike);
 
         //when
-        Optional<ReviewLike> liked = reviewLikeRepository.findByReviewIdAndPhotographerId(
+        Optional<ReviewLike> liked = reviewLikeRepository.findByReviewIdAndUserId(
             review.getId(),
             likedPhotographer.getId());
-        Optional<ReviewLike> unLiked = reviewLikeRepository.findByReviewIdAndPhotographerId(
+        Optional<ReviewLike> unLiked = reviewLikeRepository.findByReviewIdAndUserId(
             review.getId(),
             unlikedPhotographer.getId());
 

--- a/src/test/java/net/catsnap/domain/review/repository/ReviewLikeRepositoryTest.java
+++ b/src/test/java/net/catsnap/domain/review/repository/ReviewLikeRepositoryTest.java
@@ -117,7 +117,7 @@ class ReviewLikeRepositoryTest {
         reviewLikeRepository.save(reviewUnliked2);
 
         //when
-        Long likeCount = reviewLikeRepository.countByReviewIdAndLiked(review.getId(), true);
+        Long likeCount = reviewLikeRepository.countByReviewId(review.getId(), true);
 
         //then
         Assertions.assertThat(likeCount).isEqualTo(2);

--- a/src/test/java/net/catsnap/domain/review/service/ReviewLikeServiceTest.java
+++ b/src/test/java/net/catsnap/domain/review/service/ReviewLikeServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.BDDMockito.given;
 import java.util.Optional;
 import net.catsnap.domain.review.entity.ReviewLike;
 import net.catsnap.domain.review.repository.ReviewLikeRepository;
+import net.catsnap.domain.user.fakeuser.entity.FakeUser;
 import net.catsnap.support.fixture.ReviewLikeFixture;
 import net.catsnap.support.security.AnonymousSecurityContext;
 import net.catsnap.support.security.MemberSecurityContext;
@@ -34,7 +35,7 @@ class ReviewLikeServiceTest {
     void 특정_리뷰에_좋아요_개수를_조회한다() {
         // given
         Long reviewId = 1L;
-        given(reviewLikeRepository.countByReviewId(reviewId, true)).willReturn(123L);
+        given(reviewLikeRepository.countByReviewId(reviewId)).willReturn(123L);
 
         // when
         Long likedCount = reviewLikeService.getReviewLikeCount(reviewId);
@@ -52,11 +53,12 @@ class ReviewLikeServiceTest {
             MemberSecurityContext.setContext();
             Long reviewId = 1L;
             ReviewLike reviewLike = ReviewLikeFixture.reviewLike().build();
-            given(reviewLikeRepository.findByReviewIdAndMemberId(reviewId,
+            given(reviewLikeRepository.findByReviewIdAndUserId(reviewId,
                 MemberSecurityContext.MEMBER_ID))
                 .willReturn(Optional.of(reviewLike));
             //when
-            Boolean isLiked = reviewLikeService.isMeReviewLiked(reviewId);
+            Boolean isLiked = reviewLikeService.isMeReviewLiked(reviewId,
+                MemberSecurityContext.MEMBER_ID);
 
             //then
             Assertions.assertThat(isLiked).isTrue();
@@ -70,11 +72,12 @@ class ReviewLikeServiceTest {
             // given
             MemberSecurityContext.setContext();
             Long reviewId = 1L;
-            given(reviewLikeRepository.findByReviewIdAndMemberId(reviewId,
+            given(reviewLikeRepository.findByReviewIdAndUserId(reviewId,
                 MemberSecurityContext.MEMBER_ID))
                 .willReturn(Optional.empty());
             //when
-            Boolean isLiked = reviewLikeService.isMeReviewLiked(reviewId);
+            Boolean isLiked = reviewLikeService.isMeReviewLiked(reviewId,
+                MemberSecurityContext.MEMBER_ID);
 
             //then
             Assertions.assertThat(isLiked).isFalse();
@@ -89,11 +92,12 @@ class ReviewLikeServiceTest {
             PhotographerSecurityContext.setContext();
             Long reviewId = 1L;
             ReviewLike reviewLike = ReviewLikeFixture.reviewLike().build();
-            given(reviewLikeRepository.findByReviewIdAndPhotographerId(reviewId,
+            given(reviewLikeRepository.findByReviewIdAndUserId(reviewId,
                 PhotographerSecurityContext.Photographer_ID))
                 .willReturn(Optional.of(reviewLike));
             //when
-            Boolean isLiked = reviewLikeService.isMeReviewLiked(reviewId);
+            Boolean isLiked = reviewLikeService.isMeReviewLiked(reviewId,
+                PhotographerSecurityContext.Photographer_ID);
 
             //then
             Assertions.assertThat(isLiked).isTrue();
@@ -107,11 +111,12 @@ class ReviewLikeServiceTest {
 // given
             PhotographerSecurityContext.setContext();
             Long reviewId = 1L;
-            given(reviewLikeRepository.findByReviewIdAndPhotographerId(reviewId,
+            given(reviewLikeRepository.findByReviewIdAndUserId(reviewId,
                 PhotographerSecurityContext.Photographer_ID))
                 .willReturn(Optional.empty());
             //when
-            Boolean isLiked = reviewLikeService.isMeReviewLiked(reviewId);
+            Boolean isLiked = reviewLikeService.isMeReviewLiked(reviewId,
+                PhotographerSecurityContext.Photographer_ID);
 
             //then
             Assertions.assertThat(isLiked).isFalse();
@@ -125,7 +130,7 @@ class ReviewLikeServiceTest {
             // given
             AnonymousSecurityContext.setContext();
             // when
-            Boolean isLiked = reviewLikeService.isMeReviewLiked(1L);
+            Boolean isLiked = reviewLikeService.isMeReviewLiked(1L, FakeUser.fakeUserId);
 
             // then
             Assertions.assertThat(isLiked).isFalse();

--- a/src/test/java/net/catsnap/domain/review/service/ReviewLikeServiceTest.java
+++ b/src/test/java/net/catsnap/domain/review/service/ReviewLikeServiceTest.java
@@ -34,7 +34,7 @@ class ReviewLikeServiceTest {
     void 특정_리뷰에_좋아요_개수를_조회한다() {
         // given
         Long reviewId = 1L;
-        given(reviewLikeRepository.countByReviewIdAndLiked(reviewId, true)).willReturn(123L);
+        given(reviewLikeRepository.countByReviewId(reviewId, true)).willReturn(123L);
 
         // when
         Long likedCount = reviewLikeService.getReviewLikeCount(reviewId);

--- a/src/test/java/net/catsnap/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/net/catsnap/domain/review/service/ReviewServiceTest.java
@@ -32,7 +32,6 @@ import net.catsnap.support.fixture.ReservationFixture;
 import net.catsnap.support.fixture.ReviewFixture;
 import net.catsnap.support.fixture.ReviewLikeFixture;
 import net.catsnap.support.security.MemberSecurityContext;
-import net.catsnap.support.security.PhotographerSecurityContext;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -195,7 +194,7 @@ class ReviewServiceTest {
 
                 // 좋아요를 처음 누르는 경우
                 given(
-                    reviewLikeRepository.findByReviewIdAndMemberId(review.getId(), member.getId()))
+                    reviewLikeRepository.findByReviewIdAndUserId(review.getId(), member.getId()))
                     .willReturn(Optional.empty());
                 given(memberRepository.getReferenceById(member.getId()))
                     .willReturn(member);
@@ -203,7 +202,7 @@ class ReviewServiceTest {
                     .willReturn(Optional.of(review));
 
                 //when
-                reviewService.toggleReviewLike(review.getId());
+                reviewService.toggleReviewLike(review.getId(), member.getId());
 
                 //then
                 verify(reviewLikeRepository, times(1)).save(any());
@@ -224,134 +223,16 @@ class ReviewServiceTest {
 
                 // 좋아요를 누른 적 있는 경우
                 given(
-                    reviewLikeRepository.findByReviewIdAndMemberId(review.getId(), member.getId()))
+                    reviewLikeRepository.findByReviewIdAndUserId(review.getId(), member.getId()))
                     .willReturn(Optional.of(reviewLike));
 
                 //when
-                reviewService.toggleReviewLike(review.getId());
+                reviewService.toggleReviewLike(review.getId(), member.getId());
 
                 //then
-                Assertions.assertThat(reviewLike.getLiked()).isFalse();
                 verify(reviewLikeRepository, times(0)).save(reviewLike);
             }
 
-            @Test
-            void 사용자_좋아요_3번째_클릭() {
-                Member member = MemberFixture.member()
-                    .id(MemberSecurityContext.MEMBER_ID)
-                    .build();
-                Review review = ReviewFixture.review()
-                    .id(1L)
-                    .build();
-                ReviewLike reviewLike = ReviewLikeFixture.reviewLike()
-                    .id(1L)
-                    .liked(false)
-                    .build();
-
-                // 좋아요를 누른 적 있는 경우
-                given(
-                    reviewLikeRepository.findByReviewIdAndMemberId(review.getId(), member.getId()))
-                    .willReturn(Optional.of(reviewLike));
-
-                //when
-                reviewService.toggleReviewLike(review.getId());
-
-                //then
-                Assertions.assertThat(reviewLike.getLiked()).isTrue();
-                verify(reviewLikeRepository, times(0)).save(reviewLike);
-            }
-        }
-
-        @Nested
-        class 사진_작가_좋아요_토글 {
-
-            @BeforeEach
-            void beforeEach() {
-                PhotographerSecurityContext.setContext();
-            }
-
-            @AfterEach
-            void afterEach() {
-                PhotographerSecurityContext.clearContext();
-            }
-
-            @Test
-            void 사진작가_좋아요_최초_클릭() {
-                // given
-                Photographer photographer = PhotographerFixture.photographer()
-                    .id(PhotographerSecurityContext.Photographer_ID)
-                    .build();
-                Review review = ReviewFixture.review()
-                    .id(1L)
-                    .build();
-
-                // 좋아요를 처음 누르는 경우
-                given(reviewLikeRepository.findByReviewIdAndPhotographerId(review.getId(),
-                    photographer.getId()))
-                    .willReturn(Optional.empty());
-                given(photographerRepository.getReferenceById(photographer.getId()))
-                    .willReturn(photographer);
-                given(reviewRepository.findById(1L))
-                    .willReturn(Optional.of(review));
-
-                //when
-                reviewService.toggleReviewLike(review.getId());
-
-                //then
-                verify(reviewLikeRepository, times(1)).save(any());
-            }
-
-            @Test
-            void 사용자_좋아요_2번째_클릭_좋아요_취소() {
-                // given
-                Photographer photographer = PhotographerFixture.photographer()
-                    .id(PhotographerSecurityContext.Photographer_ID)
-                    .build();
-                Review review = ReviewFixture.review()
-                    .id(1L)
-                    .build();
-                ReviewLike reviewLike = ReviewLikeFixture.reviewLike()
-                    .id(1L)
-                    .build();
-
-                // 좋아요를 누른 적 있는 경우
-                given(reviewLikeRepository.findByReviewIdAndPhotographerId(review.getId(),
-                    photographer.getId()))
-                    .willReturn(Optional.of(reviewLike));
-
-                //when
-                reviewService.toggleReviewLike(review.getId());
-
-                //then
-                Assertions.assertThat(reviewLike.getLiked()).isFalse();
-                verify(reviewLikeRepository, times(0)).save(reviewLike);
-            }
-
-            @Test
-            void 사용자_좋아요_3번째_클릭() {
-                Photographer photographer = PhotographerFixture.photographer()
-                    .id(PhotographerSecurityContext.Photographer_ID)
-                    .build();
-                Review review = ReviewFixture.review()
-                    .id(1L)
-                    .build();
-                ReviewLike reviewLike = ReviewLikeFixture.reviewLike()
-                    .id(1L)
-                    .liked(false)
-                    .build();
-
-                // 좋아요를 누른 적 있는 경우
-                given(reviewLikeRepository.findByReviewIdAndPhotographerId(review.getId(),
-                    photographer.getId()))
-                    .willReturn(Optional.of(reviewLike));
-
-                //when
-                reviewService.toggleReviewLike(review.getId());
-
-                //then
-                Assertions.assertThat(reviewLike.getLiked()).isTrue();
-                verify(reviewLikeRepository, times(0)).save(reviewLike);
-            }
         }
     }
 }

--- a/src/test/java/net/catsnap/support/fixture/ReviewLikeFixture.java
+++ b/src/test/java/net/catsnap/support/fixture/ReviewLikeFixture.java
@@ -2,16 +2,13 @@ package net.catsnap.support.fixture;
 
 import net.catsnap.domain.review.entity.Review;
 import net.catsnap.domain.review.entity.ReviewLike;
-import net.catsnap.domain.user.member.entity.Member;
-import net.catsnap.domain.user.photographer.entity.Photographer;
+import net.catsnap.domain.user.entity.User;
 
 public class ReviewLikeFixture {
 
     private Long id;
     private Review review = ReviewFixture.review().build();
-    private Member member = MemberFixture.member().build();
-    private Photographer photographer = PhotographerFixture.photographer().build();
-    private Boolean liked = true;
+    private User user;
 
     public static ReviewLikeFixture reviewLike() {
         return new ReviewLikeFixture();
@@ -27,18 +24,8 @@ public class ReviewLikeFixture {
         return this;
     }
 
-    public ReviewLikeFixture member(Member member) {
-        this.member = member;
-        return this;
-    }
-
-    public ReviewLikeFixture photographer(Photographer photographer) {
-        this.photographer = photographer;
-        return this;
-    }
-
-    public ReviewLikeFixture liked(Boolean liked) {
-        this.liked = liked;
+    public ReviewLikeFixture user(User user) {
+        this.user = user;
         return this;
     }
 
@@ -46,9 +33,7 @@ public class ReviewLikeFixture {
         return ReviewLike.builder()
             .id(id)
             .review(review)
-            .member(member)
-            .photographer(photographer)
-            .liked(liked)
+            .user(user)
             .build();
     }
 }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[feat]: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #116 

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->

### 리팩토링 전
모델(사용자)와 작가가 모두 리뷰에 좋아요를 누를 수 있으므로 기존의 엔티티는 아래와 같았다. 이들의 공통 클래스가 없기 때문에 모델과 작가의 엔티티 모두를 들고 있어야 했다,
![image](https://github.com/user-attachments/assets/ffe6bf22-fb98-4e79-9935-3763dec78ca5)

따라서 좋아요를 누르는 로직이 아래와 같이 로직은 비슷하나, 코드가 2개로 나누어져 있었다. (작가가 좋아요를 누르는 로직도 비슷하다)
![image](https://github.com/user-attachments/assets/06283516-f0d3-479a-9d8a-7178f5a69999)
![image](https://github.com/user-attachments/assets/80da747e-abe4-46fc-a9fc-56a1f616b199)

또한 리뷰를 조회할 때, 내가 해당 리뷰에 조아요를 눌렀는지 확인하는 로직 또한 비슷한 코드의  if문의 나열이 있습니다.
![image](https://github.com/user-attachments/assets/7ae3fdf1-0ccd-44f2-b28b-f26b91de25ca)


**이 코드들의 문제점을 정리하면...**
1. 리뷰에 좋아요를 누르는 것은 모델과 작가 모두 할 수 있는 행동이나, ReviewLike 엔티티에는 모델이 좋아요를 누르면 작가 필드가 null, 작가가 좋아요를 누르면 모델 필드가 null인값을 가집니다.
2. 1번의 설계에 따라 작가가 좋아요를 누르는 로직과 모델이 좋아요를 누르는 로직을 2번 작성해야 한다.
3. 권한을 확인하는 로직이 서비스단까지 침투합니다. 이는 사용자와 작가가 좋아요를 누르는 API는 1개이나, 서비스로직은 분리되어 있기 때문에 발생합니다.
4. 글을 조회할 때 내가 조야요를 눌렀는지 확인하는 로직에서는, 비로그인 사용자, 작가, 모델 3개의 분기가 발생함

### 리팩토링 후
![image](https://github.com/user-attachments/assets/03bd6cff-58d1-414f-857e-cdc45931a7d0)
- closed:#108 -> 해당 리팩토링이 공통 필드를 User 클래스로 상속후 Member와 Photographer를 Inheritance(strategy = InheritanceType.JOINED) 방식으로 상속 구현했습니다.

따라서 ReviewLike 엔티티는 구체적인 Member와 Photographer를 구분할 필요 없이 User과만 연관되도록 하였습니다.

**리팩토링 전의 문제점이 아래와 같이 해결되었습니다.**
1. ReviewLike 엔티티가 Member, Photographer 모두에 의존 -> User에만 의존해 null값을 가지지 않음
2. 좋아요 로직이 작가, 모델 모두 작성해야 함 -> User에 대한 로직을 작성하면 됨
3.  권한을 확인하는 로직이 서비스단까지 침투 -> 권한 확인이 필요 없기 때문에(작가, 모델만 컨트롤러에서 허용함, 권한에 관계없이 User클래스 이용)  해당 로직 삭제
4. fakeUser를 두어(User 클래스이나, 데이터베이스의 id가 -1임),  로그인 사용자와 비로그인 사용자가 같은 로직을 사용해 분기가 발생하지 않습니다.


리뷰에 좋아요를 누르는 코드
![image](https://github.com/user-attachments/assets/965f73ec-bf65-4ffd-ab05-346435be7819)

자신이 리뷰에 좋아요를 눌렀는지 확인하는 코드
![image](https://github.com/user-attachments/assets/21400228-5d76-46e1-b527-e3af37986999)
