### PR TITLE
[REFACT] 로그인 성공 시, 엑세스 토큰을 바디에 전달 (#122)

### DIFF
--- a/src/main/java/net/catsnap/domain/auth/controller/MemberAuthController.java
+++ b/src/main/java/net/catsnap/domain/auth/controller/MemberAuthController.java
@@ -11,6 +11,7 @@ import net.catsnap.domain.auth.interceptor.AnyUser;
 import net.catsnap.domain.auth.service.MemberAuthService;
 import net.catsnap.global.result.ResultResponse;
 import net.catsnap.global.result.code.MemberResultCode;
+import net.catsnap.global.security.dto.AccessTokenResponse;
 import net.catsnap.global.security.dto.SecurityRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -47,17 +48,19 @@ public class MemberAuthController {
      *로그인 처리는 Spring Security의 필터로 처리하므로 해당 메서드는 필요하지 않습니다.
      *해당 컨트롤러는 API 명세만을 위한 것입니다.
      */
-    @Operation(summary = "자체 서비스 API(구현 완료)", description = "자체 서비스 로그인(네이버나 카카오 등의 OAuth 로그인이 아닌 "
-        +
-        "자체 서비스 로그인)을 할 수 있는 API입니다. 로그인 성공 시 헤더에 accessToken: Bearer {accessToken}과 " +
-        "쿠키에 refreshToken: {refreshToken}을 담아서 반환합니다.")
+    @Operation(summary = "자체 서비스 API(구현 완료)",
+        description = """
+            자체 서비스 로그인 API입니다. (네이버, 카카오 등 OAuth 로그인 아님)
+            로그인 성공 시 리프레시 토큰을 쿠키에 담아서 반환합니다.
+            """
+    )
     @ApiResponses({
         @ApiResponse(responseCode = "200 SY000", description = "로그인 성공"),
         @ApiResponse(responseCode = "401 EY000", description = "로그인 실패 (아이디 또는 비밀번호가 일치하지 않음)"),
         @ApiResponse(responseCode = "400 EY001", description = "로그인 실패 (잘못된 로그인 API 요청 형식)"),
     })
     @PostMapping("/member/signin/catsnap")
-    public ResultResponse<?> signIn(
+    public ResponseEntity<ResultResponse<AccessTokenResponse>> signIn(
         @Parameter(description = "로그인 양식", required = true)
         @RequestBody
         SecurityRequest.CatsnapSignInRequest memberSignIn
@@ -65,14 +68,17 @@ public class MemberAuthController {
         return null;
     }
 
-    @Operation(summary = "네이버 소셜로그인 API(구현 완료)", description =
-        "네이버 소셜로그인으로 회원가입과 로그인을 할 수 있는 API입니다. " +
-            "단순하게 소셜로그인을 하면 헤더에 accessToken: Bearer {accessToken}과 쿠키에 refreshToken: {refreshToken}을 담아서 반환합니다.")
+    @Operation(summary = "네이버 소셜로그인 API(구현 완료)",
+        description = """
+            네이버 소셜로그인으로 회원가입과 로그인을 할 수 있는 API입니다.
+            로그인 성공 시 리프레시 토큰을 쿠키에 담아서 반환합니다.
+            """
+    )
     @ApiResponses({
         @ApiResponse(responseCode = "201 SM000", description = "성공적으로 회원가입(로그인)을 했습니다."),
     })
     @PostMapping("/oauth2/authorization/naver")
-    public ResultResponse<?> oAuthSignUp(
+    public ResponseEntity<ResultResponse<AccessTokenResponse>> oAuthSignUp(
     ) {
         return null;
     }

--- a/src/main/java/net/catsnap/domain/auth/controller/PhotographerAuthController.java
+++ b/src/main/java/net/catsnap/domain/auth/controller/PhotographerAuthController.java
@@ -11,6 +11,7 @@ import net.catsnap.domain.auth.interceptor.AnyUser;
 import net.catsnap.domain.auth.service.PhotographerAuthService;
 import net.catsnap.global.result.ResultResponse;
 import net.catsnap.global.result.code.PhotographerResultCode;
+import net.catsnap.global.security.dto.AccessTokenResponse;
 import net.catsnap.global.security.dto.SecurityRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -53,7 +54,7 @@ public class PhotographerAuthController {
         @ApiResponse(responseCode = "400 EY001", description = "로그인 실패 (잘못된 로그인 API 요청 형식)"),
     })
     @PostMapping("/signin/catsnap")
-    public ResultResponse<?> signIn(
+    public ResponseEntity<ResultResponse<AccessTokenResponse>> signIn(
         @Parameter(description = "로그인 양식", required = true)
         @RequestBody
         SecurityRequest.CatsnapSignInRequest photographerSignIn

--- a/src/main/java/net/catsnap/domain/auth/controller/RefreshTokenController.java
+++ b/src/main/java/net/catsnap/domain/auth/controller/RefreshTokenController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import net.catsnap.global.result.ResultResponse;
+import net.catsnap.global.security.dto.AccessTokenResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -25,7 +26,7 @@ public class RefreshTokenController {
         @ApiResponse(responseCode = "400 EY003", description = "Jwt 토큰 서명이 올바르지 않습니다."),
     })
     @GetMapping("/refresh/access-token")
-    public ResponseEntity<ResultResponse<?>> signUp(
+    public ResponseEntity<ResultResponse<AccessTokenResponse>> signUp(
         @CookieValue(value = "refreshToken", required = true) String refreshToken
     ) {
         return null;

--- a/src/main/java/net/catsnap/global/security/dto/AccessTokenResponse.java
+++ b/src/main/java/net/catsnap/global/security/dto/AccessTokenResponse.java
@@ -1,0 +1,8 @@
+package net.catsnap.global.security.dto;
+
+public record AccessTokenResponse(String accessToken) {
+
+    public static AccessTokenResponse of(String accessToken) {
+        return new AccessTokenResponse(accessToken);
+    }
+}

--- a/src/main/java/net/catsnap/global/security/filter/RefreshAccessTokenFilter.java
+++ b/src/main/java/net/catsnap/global/security/filter/RefreshAccessTokenFilter.java
@@ -1,10 +1,5 @@
 package net.catsnap.global.security.filter;
 
-import net.catsnap.global.result.code.SecurityResultCode;
-import net.catsnap.global.result.errorcode.SecurityErrorCode;
-import net.catsnap.global.security.authenticationToken.CatsnapAuthenticationToken;
-import net.catsnap.global.security.util.ServletSecurityResponse;
-import net.catsnap.global.security.util.TokenAuthentication;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
@@ -17,6 +12,12 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import net.catsnap.global.result.code.SecurityResultCode;
+import net.catsnap.global.result.errorcode.SecurityErrorCode;
+import net.catsnap.global.security.authenticationToken.CatsnapAuthenticationToken;
+import net.catsnap.global.security.dto.AccessTokenResponse;
+import net.catsnap.global.security.util.ServletSecurityResponse;
+import net.catsnap.global.security.util.TokenAuthentication;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @RequiredArgsConstructor
@@ -69,10 +70,10 @@ public class RefreshAccessTokenFilter extends OncePerRequestFilter {
                 accessTokenCookie.setPath("/refresh/access-token");
 
                 response.setStatus(HttpServletResponse.SC_OK);
-                response.setHeader("Authorization", "Bearer " + accessToken);
                 response.addCookie(accessTokenCookie);
+                AccessTokenResponse accessTokenResponse = AccessTokenResponse.of(accessToken);
                 servletSecurityResponse.responseBody(response,
-                    SecurityResultCode.COMPLETE_REFRESH_TOKEN);
+                    SecurityResultCode.COMPLETE_REFRESH_TOKEN, accessTokenResponse);
             } catch (UnsupportedJwtException | MalformedJwtException e) {
                 unsuccessfulAuthentication(request, response, SecurityErrorCode.WRONG_JWT_TOKEN);
             } catch (ExpiredJwtException e) {

--- a/src/main/java/net/catsnap/global/security/filter/SignInAuthenticationFilter.java
+++ b/src/main/java/net/catsnap/global/security/filter/SignInAuthenticationFilter.java
@@ -12,6 +12,7 @@ import java.nio.charset.StandardCharsets;
 import net.catsnap.global.result.code.SecurityResultCode;
 import net.catsnap.global.result.errorcode.SecurityErrorCode;
 import net.catsnap.global.security.authenticationToken.CatsnapAuthenticationToken;
+import net.catsnap.global.security.dto.AccessTokenResponse;
 import net.catsnap.global.security.dto.SecurityRequest;
 import net.catsnap.global.security.util.ServletSecurityResponse;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -86,9 +87,10 @@ public class SignInAuthenticationFilter extends AbstractAuthenticationProcessing
         accessTokenCookie.setPath("/refresh/access-token");
 
         response.setStatus(HttpServletResponse.SC_OK);
-        response.setHeader("Authorization", "Bearer " + accessToken);
         response.addCookie(accessTokenCookie);
-        servletSecurityResponse.responseBody(response, SecurityResultCode.COMPLETE_SIGN_IN);
+        AccessTokenResponse accessTokenResponse = new AccessTokenResponse(accessToken);
+        servletSecurityResponse.responseBody(response, SecurityResultCode.COMPLETE_SIGN_IN,
+            accessTokenResponse);
     }
 
     @Override

--- a/src/main/java/net/catsnap/global/security/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/net/catsnap/global/security/handler/OAuth2LoginSuccessHandler.java
@@ -7,6 +7,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import net.catsnap.global.result.code.SecurityResultCode;
+import net.catsnap.global.security.dto.AccessTokenResponse;
 import net.catsnap.global.security.oauth2user.MemberOAuth2User;
 import net.catsnap.global.security.util.ServletSecurityResponse;
 import org.springframework.security.core.Authentication;
@@ -46,8 +47,9 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         accessTokenCookie.setPath("/refresh/access-token");
 
         response.setStatus(HttpServletResponse.SC_OK);
-        response.setHeader("Authorization", "Bearer " + accessToken);
         response.addCookie(accessTokenCookie);
-        servletSecurityResponse.responseBody(response, SecurityResultCode.COMPLETE_SIGN_IN);
+        AccessTokenResponse accessTokenResponse = new AccessTokenResponse(accessToken);
+        servletSecurityResponse.responseBody(response, SecurityResultCode.COMPLETE_SIGN_IN,
+            accessTokenResponse);
     }
 }

--- a/src/main/java/net/catsnap/global/security/util/ServletSecurityResponse.java
+++ b/src/main/java/net/catsnap/global/security/util/ServletSecurityResponse.java
@@ -10,6 +10,7 @@ import javax.crypto.SecretKey;
 import lombok.RequiredArgsConstructor;
 import net.catsnap.global.result.ResultCode;
 import net.catsnap.global.result.ResultResponse;
+import net.catsnap.global.security.dto.AccessTokenResponse;
 
 @RequiredArgsConstructor
 public class ServletSecurityResponse {
@@ -29,10 +30,11 @@ public class ServletSecurityResponse {
         response.getWriter().write(jsonResponse);
     }
 
-    public void responseBody(HttpServletResponse response, ResultCode resultCode, Object data)
+    public void responseBody(HttpServletResponse response, ResultCode resultCode,
+        AccessTokenResponse accessTokenResponse)
         throws IOException {
         String jsonResponse = objectMapper.writeValueAsString(
-            ResultResponse.of(resultCode, data));
+            ResultResponse.of(resultCode, accessTokenResponse));
         response.setCharacterEncoding("UTF-8");
         response.setContentType("application/json");
         response.getWriter().write(jsonResponse);

--- a/src/main/java/net/catsnap/global/security/util/ServletSecurityResponse.java
+++ b/src/main/java/net/catsnap/global/security/util/ServletSecurityResponse.java
@@ -1,7 +1,5 @@
 package net.catsnap.global.security.util;
 
-import net.catsnap.global.result.ResultCode;
-import net.catsnap.global.result.ResultResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.Jwts;
 import jakarta.servlet.http.HttpServletResponse;
@@ -10,6 +8,8 @@ import java.util.Date;
 import java.util.Map;
 import javax.crypto.SecretKey;
 import lombok.RequiredArgsConstructor;
+import net.catsnap.global.result.ResultCode;
+import net.catsnap.global.result.ResultResponse;
 
 @RequiredArgsConstructor
 public class ServletSecurityResponse {
@@ -24,6 +24,15 @@ public class ServletSecurityResponse {
         throws IOException {
         String jsonResponse = objectMapper.writeValueAsString(
             ResultResponse.ofNotEntity(resultCode));
+        response.setCharacterEncoding("UTF-8");
+        response.setContentType("application/json");
+        response.getWriter().write(jsonResponse);
+    }
+
+    public void responseBody(HttpServletResponse response, ResultCode resultCode, Object data)
+        throws IOException {
+        String jsonResponse = objectMapper.writeValueAsString(
+            ResultResponse.of(resultCode, data));
         response.setCharacterEncoding("UTF-8");
         response.setContentType("application/json");
         response.getWriter().write(jsonResponse);


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[feat]: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #122 

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->
기존 : 로그인 성공 시, 엑세스 토큰을 헤더에 전달했습니다.

리팩토링 후 : 로그인 성공 시, 엑세스 토큰을 바디에 전달합니다.