### PR TITLE
[REFACT] jwt 발급 로직 클래스 분리 (#124)

### DIFF
--- a/src/main/java/net/catsnap/global/security/SecurityConfig.java
+++ b/src/main/java/net/catsnap/global/security/SecurityConfig.java
@@ -15,6 +15,7 @@ import net.catsnap.global.security.handler.OAuth2LoginSuccessHandler;
 import net.catsnap.global.security.provider.CatsnapAuthenticationProvider;
 import net.catsnap.global.security.service.CatsnapUserDetailsService;
 import net.catsnap.global.security.service.MemberOAuth2UserService;
+import net.catsnap.global.security.util.AuthTokenIssuer;
 import net.catsnap.global.security.util.JwtTokenAuthentication;
 import net.catsnap.global.security.util.ServletSecurityResponse;
 import org.springframework.context.annotation.Bean;
@@ -46,6 +47,7 @@ public class SecurityConfig {
     private final SecretKey secretKey;
     private final MemberOAuth2UserService memberOAuth2UserService;
     private final UserRepository userRepository;
+    private final AuthTokenIssuer authTokenIssuer;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -104,7 +106,7 @@ public class SecurityConfig {
                 .configurationSource(corsConfigurationSource()))
             .addFilterAt(
                 new SignInAuthenticationFilter(authenticationManager(), objectMapper,
-                    servletSecurityResponse),
+                    servletSecurityResponse, authTokenIssuer),
                 BasicAuthenticationFilter.class
             )
             .addFilterAt(

--- a/src/main/java/net/catsnap/global/security/SecurityConfig.java
+++ b/src/main/java/net/catsnap/global/security/SecurityConfig.java
@@ -16,7 +16,7 @@ import net.catsnap.global.security.provider.CatsnapAuthenticationProvider;
 import net.catsnap.global.security.service.CatsnapUserDetailsService;
 import net.catsnap.global.security.service.MemberOAuth2UserService;
 import net.catsnap.global.security.util.AuthTokenIssuer;
-import net.catsnap.global.security.util.JwtTokenAuthentication;
+import net.catsnap.global.security.util.JwtAuthTokenAuthenticator;
 import net.catsnap.global.security.util.ServletSecurityResponse;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -72,8 +72,8 @@ public class SecurityConfig {
     }
 
     @Bean
-    public JwtTokenAuthentication jwtTokenAuthentication() {
-        return new JwtTokenAuthentication(secretKey);
+    public JwtAuthTokenAuthenticator jwtTokenAuthentication() {
+        return new JwtAuthTokenAuthenticator(secretKey);
     }
 
     @Bean

--- a/src/main/java/net/catsnap/global/security/SecurityConfig.java
+++ b/src/main/java/net/catsnap/global/security/SecurityConfig.java
@@ -91,7 +91,7 @@ public class SecurityConfig {
 
     @Bean
     public OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler() {
-        return new OAuth2LoginSuccessHandler(servletSecurityResponse);
+        return new OAuth2LoginSuccessHandler(servletSecurityResponse, authTokenIssuer);
     }
 
     @Bean
@@ -110,7 +110,8 @@ public class SecurityConfig {
                 BasicAuthenticationFilter.class
             )
             .addFilterAt(
-                new RefreshAccessTokenFilter(servletSecurityResponse, jwtTokenAuthentication()),
+                new RefreshAccessTokenFilter(servletSecurityResponse, jwtTokenAuthentication(),
+                    authTokenIssuer),
                 BasicAuthenticationFilter.class
             )
             .oauth2Login((oauth2) -> oauth2

--- a/src/main/java/net/catsnap/global/security/dto/AuthTokenDTO.java
+++ b/src/main/java/net/catsnap/global/security/dto/AuthTokenDTO.java
@@ -1,0 +1,8 @@
+package net.catsnap.global.security.dto;
+
+public record AuthTokenDTO(String accessToken, String refreshToken) {
+
+    public static AuthTokenDTO of(String accessToken, String refreshToken) {
+        return new AuthTokenDTO(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/net/catsnap/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/net/catsnap/global/security/filter/JwtAuthenticationFilter.java
@@ -15,8 +15,8 @@ import net.catsnap.global.result.errorcode.SecurityErrorCode;
 import net.catsnap.global.security.authenticationToken.AnonymousAuthenticationToken;
 import net.catsnap.global.security.authenticationToken.CatsnapAuthenticationToken;
 import net.catsnap.global.security.authority.CatsnapAuthority;
+import net.catsnap.global.security.util.AuthTokenAuthenticator;
 import net.catsnap.global.security.util.ServletSecurityResponse;
-import net.catsnap.global.security.util.TokenAuthentication;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -25,7 +25,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final ServletSecurityResponse servletSecurityResponse;
-    private final TokenAuthentication tokenAuthentication;
+    private final AuthTokenAuthenticator authTokenAuthenticator;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
@@ -39,7 +39,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         } else {
             jwt = parseJwt(jwt);
             try {
-                CatsnapAuthenticationToken authenticationToken = tokenAuthentication.authenticate(
+                CatsnapAuthenticationToken authenticationToken = authTokenAuthenticator.authTokenAuthenticate(
                     jwt);
                 SecurityContextHolder.getContext().setAuthentication(authenticationToken);
                 filterChain.doFilter(request, response);

--- a/src/main/java/net/catsnap/global/security/filter/RefreshAccessTokenFilter.java
+++ b/src/main/java/net/catsnap/global/security/filter/RefreshAccessTokenFilter.java
@@ -17,16 +17,16 @@ import net.catsnap.global.result.errorcode.SecurityErrorCode;
 import net.catsnap.global.security.authenticationToken.CatsnapAuthenticationToken;
 import net.catsnap.global.security.dto.AccessTokenResponse;
 import net.catsnap.global.security.dto.AuthTokenDTO;
+import net.catsnap.global.security.util.AuthTokenAuthenticator;
 import net.catsnap.global.security.util.AuthTokenIssuer;
 import net.catsnap.global.security.util.ServletSecurityResponse;
-import net.catsnap.global.security.util.TokenAuthentication;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @RequiredArgsConstructor
 public class RefreshAccessTokenFilter extends OncePerRequestFilter {
 
     private final ServletSecurityResponse servletSecurityResponse;
-    private final TokenAuthentication tokenAuthentication;
+    private final AuthTokenAuthenticator authTokenAuthenticator;
     private final AuthTokenIssuer authTokenIssuer;
 
     @Override
@@ -42,7 +42,7 @@ public class RefreshAccessTokenFilter extends OncePerRequestFilter {
         } else {
             String refreshToken = refreshTokenCookie.get().getValue();
             try {
-                CatsnapAuthenticationToken authenticationToken = tokenAuthentication.authenticate(
+                CatsnapAuthenticationToken authenticationToken = authTokenAuthenticator.authTokenAuthenticate(
                     refreshToken);
 
                 AuthTokenDTO authTokenDTO = authTokenIssuer.issueAuthToken(authenticationToken);

--- a/src/main/java/net/catsnap/global/security/filter/RefreshAccessTokenFilter.java
+++ b/src/main/java/net/catsnap/global/security/filter/RefreshAccessTokenFilter.java
@@ -16,6 +16,8 @@ import net.catsnap.global.result.code.SecurityResultCode;
 import net.catsnap.global.result.errorcode.SecurityErrorCode;
 import net.catsnap.global.security.authenticationToken.CatsnapAuthenticationToken;
 import net.catsnap.global.security.dto.AccessTokenResponse;
+import net.catsnap.global.security.dto.AuthTokenDTO;
+import net.catsnap.global.security.util.AuthTokenIssuer;
 import net.catsnap.global.security.util.ServletSecurityResponse;
 import net.catsnap.global.security.util.TokenAuthentication;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -25,6 +27,7 @@ public class RefreshAccessTokenFilter extends OncePerRequestFilter {
 
     private final ServletSecurityResponse servletSecurityResponse;
     private final TokenAuthentication tokenAuthentication;
+    private final AuthTokenIssuer authTokenIssuer;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
@@ -41,28 +44,10 @@ public class RefreshAccessTokenFilter extends OncePerRequestFilter {
             try {
                 CatsnapAuthenticationToken authenticationToken = tokenAuthentication.authenticate(
                     refreshToken);
-                /*
-                 * accessToken을 생성하는 부분. 1시간 동안 유효(시간 * 분 * 초 * ms)
-                 */
-                String accessToken = servletSecurityResponse.setJwtToken("catsnap",
-                    "accessToken",
-                    authenticationToken.getPrincipal(),
-                    authenticationToken.getAuthorities(), authenticationToken.getDetails(),
-                    1L * 60L * 60L * 1000L
-                );
 
-                /*
-                 * refreshToken을 생성하는 부분. 30일 동안 유효30일(일 * 시간 * 분 * 초 * ms)
-                 */
-                String newRefreshToken = servletSecurityResponse.setJwtToken("catsnap",
-                    "refreshToken",
-                    authenticationToken.getPrincipal(),
-                    authenticationToken.getAuthorities(),
-                    authenticationToken.getDetails(),
-                    30L * 24L * 60L * 60L * 1000L
-                );
+                AuthTokenDTO authTokenDTO = authTokenIssuer.issueAuthToken(authenticationToken);
 
-                Cookie accessTokenCookie = new Cookie("refreshToken", newRefreshToken);
+                Cookie accessTokenCookie = new Cookie("refreshToken", authTokenDTO.refreshToken());
                 accessTokenCookie.setMaxAge(
                     30 * 24 * 60 * 60); //쿠키 만료 시간. 단위 : s, 30일(일 * 시간 * 분 * 초)
                 accessTokenCookie.setHttpOnly(true); // 클라이언트 측에서 쿠키 접근 금지
@@ -71,7 +56,8 @@ public class RefreshAccessTokenFilter extends OncePerRequestFilter {
 
                 response.setStatus(HttpServletResponse.SC_OK);
                 response.addCookie(accessTokenCookie);
-                AccessTokenResponse accessTokenResponse = AccessTokenResponse.of(accessToken);
+                AccessTokenResponse accessTokenResponse = AccessTokenResponse.of(
+                    authTokenDTO.accessToken());
                 servletSecurityResponse.responseBody(response,
                     SecurityResultCode.COMPLETE_REFRESH_TOKEN, accessTokenResponse);
             } catch (UnsupportedJwtException | MalformedJwtException e) {

--- a/src/main/java/net/catsnap/global/security/util/AuthTokenAuthenticator.java
+++ b/src/main/java/net/catsnap/global/security/util/AuthTokenAuthenticator.java
@@ -2,7 +2,7 @@ package net.catsnap.global.security.util;
 
 import net.catsnap.global.security.authenticationToken.CatsnapAuthenticationToken;
 
-public interface TokenAuthentication {
+public interface AuthTokenAuthenticator {
 
-    CatsnapAuthenticationToken authenticate(String token);
+    CatsnapAuthenticationToken authTokenAuthenticate(String token);
 }

--- a/src/main/java/net/catsnap/global/security/util/AuthTokenIssuer.java
+++ b/src/main/java/net/catsnap/global/security/util/AuthTokenIssuer.java
@@ -5,5 +5,5 @@ import org.springframework.security.core.Authentication;
 
 public interface AuthTokenIssuer {
 
-    AuthTokenDTO issueAccessToken(Authentication authentication);
+    AuthTokenDTO issueAuthToken(Authentication authentication);
 }

--- a/src/main/java/net/catsnap/global/security/util/AuthTokenIssuer.java
+++ b/src/main/java/net/catsnap/global/security/util/AuthTokenIssuer.java
@@ -1,0 +1,9 @@
+package net.catsnap.global.security.util;
+
+import net.catsnap.global.security.dto.AuthTokenDTO;
+import org.springframework.security.core.Authentication;
+
+public interface AuthTokenIssuer {
+
+    AuthTokenDTO issueAccessToken(Authentication authentication);
+}

--- a/src/main/java/net/catsnap/global/security/util/JwtAuthTokenAuthenticator.java
+++ b/src/main/java/net/catsnap/global/security/util/JwtAuthTokenAuthenticator.java
@@ -1,9 +1,5 @@
 package net.catsnap.global.security.util;
 
-import net.catsnap.global.security.authenticationToken.CatsnapAuthenticationToken;
-import net.catsnap.global.security.authenticationToken.MemberAuthenticationToken;
-import net.catsnap.global.security.authenticationToken.PhotographerAuthenticationToken;
-import net.catsnap.global.security.authority.CatsnapAuthority;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtParser;
@@ -16,14 +12,18 @@ import java.util.Collection;
 import java.util.List;
 import javax.crypto.SecretKey;
 import lombok.RequiredArgsConstructor;
+import net.catsnap.global.security.authenticationToken.CatsnapAuthenticationToken;
+import net.catsnap.global.security.authenticationToken.MemberAuthenticationToken;
+import net.catsnap.global.security.authenticationToken.PhotographerAuthenticationToken;
+import net.catsnap.global.security.authority.CatsnapAuthority;
 import org.springframework.security.core.GrantedAuthority;
 
 @RequiredArgsConstructor
-public class JwtTokenAuthentication implements TokenAuthentication {
+public class JwtAuthTokenAuthenticator implements AuthTokenAuthenticator {
 
     private final SecretKey secretKey;
 
-    public CatsnapAuthenticationToken authenticate(String jwt)
+    public CatsnapAuthenticationToken authTokenAuthenticate(String jwt)
         throws SignatureException, UnsupportedJwtException, MalformedJwtException, ExpiredJwtException {
 
         JwtParser jwtParser = Jwts.parserBuilder()

--- a/src/main/java/net/catsnap/global/security/util/JwtAuthTokenIssuer.java
+++ b/src/main/java/net/catsnap/global/security/util/JwtAuthTokenIssuer.java
@@ -1,0 +1,63 @@
+package net.catsnap.global.security.util;
+
+import io.jsonwebtoken.Jwts;
+import java.util.Date;
+import java.util.Map;
+import javax.crypto.SecretKey;
+import net.catsnap.global.security.dto.AuthTokenDTO;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtAuthTokenIssuer implements AuthTokenIssuer {
+
+    private final Long accessTokenExpirationMinutes;
+    private final Long refreshTokenExpirationMinutes;
+    private final SecretKey key;
+
+    public JwtAuthTokenIssuer(
+        @Value("${spring.security.expiration.access-token}")
+        Long accessTokenExpirationMinutes,
+        @Value("${spring.security.expiration.refresh-token}")
+        Long refreshTokenExpirationMinutes,
+        SecretKey key) {
+        this.accessTokenExpirationMinutes = accessTokenExpirationMinutes;
+        this.refreshTokenExpirationMinutes = refreshTokenExpirationMinutes;
+        this.key = key;
+    }
+
+    @Override
+    public AuthTokenDTO issueAccessToken(Authentication authentication) {
+        String accessToken = issueJwtToken(
+            authentication,
+            "accessToken",
+            accessTokenExpirationMinutes
+        );
+        String refreshToken = issueJwtToken(
+            authentication,
+            "refreshToken",
+            refreshTokenExpirationMinutes
+        );
+        return AuthTokenDTO.of(accessToken, refreshToken);
+    }
+
+    private String issueJwtToken(Authentication authentication, String type,
+        Long expirationMinutes) {
+        return Jwts.builder()
+            .setHeader(Map.of(
+                "provider", "catsnap",
+                "type", type
+            ))
+            .setClaims(Map.of(
+                "identifier", authentication.getPrincipal(),
+                "authorities", authentication.getAuthorities(),
+                "id", authentication.getDetails()
+            ))
+            .setIssuedAt(new Date())
+            .setExpiration(new Date(System.currentTimeMillis() + expirationMinutes * 60L * 1000L))
+            .signWith(key)
+            .compact();
+
+    }
+}

--- a/src/main/java/net/catsnap/global/security/util/JwtAuthTokenIssuer.java
+++ b/src/main/java/net/catsnap/global/security/util/JwtAuthTokenIssuer.java
@@ -28,7 +28,7 @@ public class JwtAuthTokenIssuer implements AuthTokenIssuer {
     }
 
     @Override
-    public AuthTokenDTO issueAccessToken(Authentication authentication) {
+    public AuthTokenDTO issueAuthToken(Authentication authentication) {
         String accessToken = issueJwtToken(
             authentication,
             "accessToken",

--- a/src/main/java/net/catsnap/global/security/util/ServletSecurityResponse.java
+++ b/src/main/java/net/catsnap/global/security/util/ServletSecurityResponse.java
@@ -1,12 +1,8 @@
 package net.catsnap.global.security.util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.jsonwebtoken.Jwts;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.Date;
-import java.util.Map;
-import javax.crypto.SecretKey;
 import lombok.RequiredArgsConstructor;
 import net.catsnap.global.result.ResultCode;
 import net.catsnap.global.result.ResultResponse;
@@ -16,7 +12,6 @@ import net.catsnap.global.security.dto.AccessTokenResponse;
 public class ServletSecurityResponse {
 
     private final ObjectMapper objectMapper;
-    private final SecretKey key;
 
     /*
      * 응답 메시지를 전송하는 메서드. resultCode를 받아서 ResultResponse로 변환하여 바디에 담아서 전송한다.
@@ -38,28 +33,5 @@ public class ServletSecurityResponse {
         response.setCharacterEncoding("UTF-8");
         response.setContentType("application/json");
         response.getWriter().write(jsonResponse);
-    }
-
-    /*
-     * JWT 토큰 생성 메서드.
-     *  expiration은 ms 단위임.
-     * principal은 로그인 시 사용하는 id값이고  id는 데이터베이스에서 사용되는 유저의 id값임.
-     */
-    public String setJwtToken(Object provider, Object type, Object principal, Object authorities,
-        Object id, Long expiration) {
-        return Jwts.builder()
-            .setHeader(Map.of(
-                "provider", provider,
-                "type", type
-            ))
-            .setClaims(Map.of(
-                "identifier", principal,
-                "authorities", authorities,
-                "id", id
-            ))
-            .setIssuedAt(new Date())
-            .setExpiration(new Date(System.currentTimeMillis() + expiration))
-            .signWith(key)
-            .compact();
     }
 }

--- a/src/main/java/net/catsnap/global/security/util/Util.java
+++ b/src/main/java/net/catsnap/global/security/util/Util.java
@@ -23,7 +23,7 @@ public class Util {
     }
 
     @Bean
-    public ServletSecurityResponse servletResponse(ObjectMapper objectMapper, SecretKey key) {
-        return new ServletSecurityResponse(objectMapper, key);
+    public ServletSecurityResponse servletResponse(ObjectMapper objectMapper) {
+        return new ServletSecurityResponse(objectMapper);
     }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -49,6 +49,9 @@ spring:
             user-info-uri: https://openapi.naver.com/v1/nid/me
             user-name-attribute: response
     jwt-key: testessztest123dsaqwgqtestestwqw
+    expiration:
+      access-token: 30 # 분단위
+      refresh-token: 30 # 분단위
 
   aws:
     s3:


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[feat]: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #124 

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->

기존 코드에서는 JWT 발급 과정이 JWT 토큰을 발급하는 필터에서 수행되었습니다.

이것을 JWT 토큰을 발급하는 클래스를 만들어 필터에서 구체적인 JWT 토큰(토큰으로 추상화)을 알지 못하도록 수정했습니다.
