### PR TITLE
[REFACT] 예약시 좌표를 통해 주소 알아내는 API rabbitMQ로 처리 (#139)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,9 @@ dependencies {
     // === Aws S3 의존성 추가 ===
     implementation platform('com.amazonaws:aws-java-sdk-bom:1.12.529')
     implementation 'com.amazonaws:aws-java-sdk-s3'
+    //=== rabbitmq 의존성 추가 ===
+    implementation 'org.springframework.boot:spring-boot-starter-amqp'
+    testImplementation 'org.springframework.amqp:spring-rabbit-test'
 }
 
 tasks.named('test') {

--- a/src/main/java/net/catsnap/domain/reservation/controller/MemberReservationController.java
+++ b/src/main/java/net/catsnap/domain/reservation/controller/MemberReservationController.java
@@ -17,6 +17,7 @@ import net.catsnap.domain.reservation.dto.member.response.MemberReservationInfor
 import net.catsnap.domain.reservation.dto.member.response.PhotographerReservationGuidanceResponse;
 import net.catsnap.domain.reservation.dto.member.response.ReservationBookResultResponse;
 import net.catsnap.domain.reservation.entity.ReservationQueryType;
+import net.catsnap.domain.reservation.service.MemberReservationFacade;
 import net.catsnap.domain.reservation.service.MemberReservationService;
 import net.catsnap.global.result.ResultResponse;
 import net.catsnap.global.result.SlicedData;
@@ -38,6 +39,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberReservationController {
 
     private final MemberReservationService memberReservationService;
+    private final MemberReservationFacade memberReservationFacade;
 
     @Operation(summary = "예약을 조회하는 API(구현 완료)", description = "예약을 조회하는 API입니다. 쿼리 파라미터 type으로 적절한 유형의 예약을 조회")
     @ApiResponses({
@@ -127,7 +129,7 @@ public class MemberReservationController {
         @RequestBody
         MemberReservationRequest memberReservationRequest
     ) {
-        ReservationBookResultResponse reservationBookResultResponse = memberReservationService.createReservation(
+        ReservationBookResultResponse reservationBookResultResponse = memberReservationFacade.createReservation(
             memberReservationRequest);
         return ResultResponse.of(ReservationResultCode.RESERVATION_BOOK_COMPLETE,
             reservationBookResultResponse);

--- a/src/main/java/net/catsnap/domain/reservation/entity/Reservation.java
+++ b/src/main/java/net/catsnap/domain/reservation/entity/Reservation.java
@@ -103,4 +103,16 @@ public class Reservation extends BaseTimeEntity {
             throw new OwnershipNotFoundException("해당 예약은 회원의 것이 아닙니다.");
         }
     }
+
+    public void updateCityLevel(CityLevel cityLevel) {
+        this.cityLevel = cityLevel;
+    }
+
+    public void updateDistrictLevel(DistrictLevel districtLevel) {
+        this.districtLevel = districtLevel;
+    }
+    
+    public void updateTownLevel(TownLevel townLevel) {
+        this.townLevel = townLevel;
+    }
 }

--- a/src/main/java/net/catsnap/domain/reservation/rabbitmq/AddressRequestReceiver.java
+++ b/src/main/java/net/catsnap/domain/reservation/rabbitmq/AddressRequestReceiver.java
@@ -1,0 +1,6 @@
+package net.catsnap.domain.reservation.rabbitmq;
+
+public interface AddressRequestReceiver {
+
+    public void receiveAddressRequest(Long reservationId);
+}

--- a/src/main/java/net/catsnap/domain/reservation/rabbitmq/AddressRequestSender.java
+++ b/src/main/java/net/catsnap/domain/reservation/rabbitmq/AddressRequestSender.java
@@ -2,5 +2,5 @@ package net.catsnap.domain.reservation.rabbitmq;
 
 public interface AddressRequestSender {
 
-    void SendRequestAddress(Long reservationId);
+    void sendRequestAddress(Long reservationId);
 }

--- a/src/main/java/net/catsnap/domain/reservation/rabbitmq/AddressRequestSender.java
+++ b/src/main/java/net/catsnap/domain/reservation/rabbitmq/AddressRequestSender.java
@@ -1,0 +1,6 @@
+package net.catsnap.domain.reservation.rabbitmq;
+
+public interface AddressRequestSender {
+
+    void SendRequestAddress(Long reservationId);
+}

--- a/src/main/java/net/catsnap/domain/reservation/rabbitmq/RabbitmqAddressRequestReceiver.java
+++ b/src/main/java/net/catsnap/domain/reservation/rabbitmq/RabbitmqAddressRequestReceiver.java
@@ -1,9 +1,13 @@
 package net.catsnap.domain.reservation.rabbitmq;
 
 import lombok.RequiredArgsConstructor;
+import net.catsnap.domain.reservation.dto.LegalAddressEntity;
+import net.catsnap.domain.reservation.entity.Reservation;
 import net.catsnap.domain.reservation.repository.ReservationRepository;
 import net.catsnap.domain.reservation.service.LocationService;
+import net.catsnap.global.Exception.authority.ResourceNotFoundException;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -13,7 +17,17 @@ public class RabbitmqAddressRequestReceiver implements AddressRequestReceiver {
     private final ReservationRepository reservationRepository;
 
     @Override
+    @Transactional
     public void receiveAddressRequest(Long reservationId) {
+        Reservation reservation = reservationRepository.findById(reservationId)
+            .orElseThrow(() -> new ResourceNotFoundException("해당 예약을 찾을 수 없습니다."));
 
+        LegalAddressEntity legalAddressEntity = locationService.getLegalAddressEntity(
+            reservation.getLocation().getY(),
+            reservation.getLocation().getX());
+
+        reservation.updateCityLevel(legalAddressEntity.cityLevel());
+        reservation.updateDistrictLevel(legalAddressEntity.districtLevel());
+        reservation.updateTownLevel(legalAddressEntity.townLevel());
     }
 }

--- a/src/main/java/net/catsnap/domain/reservation/rabbitmq/RabbitmqAddressRequestReceiver.java
+++ b/src/main/java/net/catsnap/domain/reservation/rabbitmq/RabbitmqAddressRequestReceiver.java
@@ -1,0 +1,19 @@
+package net.catsnap.domain.reservation.rabbitmq;
+
+import lombok.RequiredArgsConstructor;
+import net.catsnap.domain.reservation.repository.ReservationRepository;
+import net.catsnap.domain.reservation.service.LocationService;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RabbitmqAddressRequestReceiver implements AddressRequestReceiver {
+
+    private final LocationService locationService;
+    private final ReservationRepository reservationRepository;
+
+    @Override
+    public void receiveAddressRequest(Long reservationId) {
+
+    }
+}

--- a/src/main/java/net/catsnap/domain/reservation/rabbitmq/RabbitmqAddressRequestSender.java
+++ b/src/main/java/net/catsnap/domain/reservation/rabbitmq/RabbitmqAddressRequestSender.java
@@ -1,0 +1,19 @@
+package net.catsnap.domain.reservation.rabbitmq;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RabbitmqAddressRequestSender implements AddressRequestSender {
+
+    private final RabbitTemplate rabbitTemplate;
+
+
+    @Override
+    public void SendRequestAddress(Long reservationId) {
+
+    }
+
+}

--- a/src/main/java/net/catsnap/domain/reservation/rabbitmq/RabbitmqAddressRequestSender.java
+++ b/src/main/java/net/catsnap/domain/reservation/rabbitmq/RabbitmqAddressRequestSender.java
@@ -1,6 +1,7 @@
 package net.catsnap.domain.reservation.rabbitmq;
 
 import lombok.RequiredArgsConstructor;
+import net.catsnap.global.rabbitmq.RabbitmqConfig;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Component;
 
@@ -10,10 +11,8 @@ public class RabbitmqAddressRequestSender implements AddressRequestSender {
 
     private final RabbitTemplate rabbitTemplate;
 
-
     @Override
     public void SendRequestAddress(Long reservationId) {
-
+        rabbitTemplate.convertAndSend(RabbitmqConfig.ADDRESS_REQUEST_QUEUE, reservationId);
     }
-
 }

--- a/src/main/java/net/catsnap/domain/reservation/rabbitmq/RabbitmqAddressRequestSender.java
+++ b/src/main/java/net/catsnap/domain/reservation/rabbitmq/RabbitmqAddressRequestSender.java
@@ -12,7 +12,7 @@ public class RabbitmqAddressRequestSender implements AddressRequestSender {
     private final RabbitTemplate rabbitTemplate;
 
     @Override
-    public void SendRequestAddress(Long reservationId) {
+    public void sendRequestAddress(Long reservationId) {
         rabbitTemplate.convertAndSend(RabbitmqConfig.ADDRESS_REQUEST_QUEUE, reservationId);
     }
 }

--- a/src/main/java/net/catsnap/domain/reservation/service/MemberReservationFacade.java
+++ b/src/main/java/net/catsnap/domain/reservation/service/MemberReservationFacade.java
@@ -1,0 +1,26 @@
+package net.catsnap.domain.reservation.service;
+
+import lombok.RequiredArgsConstructor;
+import net.catsnap.domain.reservation.dto.member.request.MemberReservationRequest;
+import net.catsnap.domain.reservation.dto.member.response.ReservationBookResultResponse;
+import net.catsnap.domain.reservation.entity.Reservation;
+import net.catsnap.domain.reservation.rabbitmq.RabbitmqAddressRequestSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberReservationFacade {
+
+    private final MemberReservationService memberReservationService;
+    private final RabbitmqAddressRequestSender addressRequestSender;
+
+
+    public ReservationBookResultResponse createReservation(
+        MemberReservationRequest memberReservationRequest) {
+
+        Reservation reservation = memberReservationService.createReservation(
+            memberReservationRequest);
+        addressRequestSender.SendRequestAddress(reservation.getId());
+        return ReservationBookResultResponse.from(reservation);
+    }
+}

--- a/src/main/java/net/catsnap/domain/reservation/service/MemberReservationFacade.java
+++ b/src/main/java/net/catsnap/domain/reservation/service/MemberReservationFacade.java
@@ -20,7 +20,7 @@ public class MemberReservationFacade {
 
         Reservation reservation = memberReservationService.createReservation(
             memberReservationRequest);
-        addressRequestSender.SendRequestAddress(reservation.getId());
+        addressRequestSender.sendRequestAddress(reservation.getId());
         return ReservationBookResultResponse.from(reservation);
     }
 }

--- a/src/main/java/net/catsnap/domain/reservation/service/MemberReservationService.java
+++ b/src/main/java/net/catsnap/domain/reservation/service/MemberReservationService.java
@@ -4,14 +4,12 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import net.catsnap.domain.reservation.dto.LegalAddressEntity;
 import net.catsnap.domain.reservation.dto.MonthReservationCheckListResponse;
 import net.catsnap.domain.reservation.dto.MonthReservationCheckResponse;
 import net.catsnap.domain.reservation.dto.member.request.MemberReservationRequest;
 import net.catsnap.domain.reservation.dto.member.response.MemberReservationInformationListResponse;
 import net.catsnap.domain.reservation.dto.member.response.MemberReservationInformationResponse;
 import net.catsnap.domain.reservation.dto.member.response.PhotographerReservationGuidanceResponse;
-import net.catsnap.domain.reservation.dto.member.response.ReservationBookResultResponse;
 import net.catsnap.domain.reservation.entity.Program;
 import net.catsnap.domain.reservation.entity.Reservation;
 import net.catsnap.domain.reservation.entity.ReservationQueryType;
@@ -55,9 +53,8 @@ public class MemberReservationService {
     private final GeographyConverter geographyConverter;
     private final PhotographerService photographerService;
     private final ReservationValidatorService reservationValidatorService;
-    private final LocationService locationService;
 
-    public ReservationBookResultResponse createReservation(
+    public Reservation createReservation(
         MemberReservationRequest memberReservationRequest) {
         Long memberId = GetAuthenticationInfo.getUserId();
         PhotographerSetting photographerSetting = photographerService.findPhotographerSetting(
@@ -104,10 +101,6 @@ public class MemberReservationService {
         ReservationState reservationState =
             isAutoReservationAccept ? ReservationState.APPROVED : ReservationState.PENDING;
 
-        LegalAddressEntity address = locationService.getLegalAddressEntity(
-            memberReservationRequest.reservationLocation().latitude(),
-            memberReservationRequest.reservationLocation().longitude());
-
         Reservation reservation = reservationRepository.save(Reservation.builder()
             .member(member)
             .photographer(photographer)
@@ -115,16 +108,13 @@ public class MemberReservationService {
             .location(geographyConverter.toPoint(
                 memberReservationRequest.reservationLocation().latitude(),
                 memberReservationRequest.reservationLocation().longitude()))
-            .cityLevel(address.cityLevel())
-            .districtLevel(address.districtLevel())
-            .townLevel(address.townLevel())
             .locationName(memberReservationRequest.reservationLocation().locationName())
             .startTime(memberReservationRequest.startTime())
             .endTime(memberReservationRequest.startTime().plusMinutes(program.getDurationMinutes()))
             .reservationState(reservationState)
             .build());
 
-        return ReservationBookResultResponse.from(reservation);
+        return reservation;
     }
 
     public PhotographerReservationGuidanceResponse getPhotographerReservationGuidance(

--- a/src/main/java/net/catsnap/global/rabbitmq/RabbitmqConfig.java
+++ b/src/main/java/net/catsnap/global/rabbitmq/RabbitmqConfig.java
@@ -1,0 +1,42 @@
+package net.catsnap.global.rabbitmq;
+
+import net.catsnap.domain.reservation.rabbitmq.RabbitmqAddressRequestReceiver;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
+import org.springframework.amqp.rabbit.listener.adapter.MessageListenerAdapter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitmqConfig {
+
+    public static final String ADDRESS_REQUEST_QUEUE = "addressRequestQueue";
+
+    @Bean
+    public Queue addressQueue() {
+        return new Queue(ADDRESS_REQUEST_QUEUE, false);
+    }
+
+    @Bean
+    public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
+        return new RabbitTemplate(connectionFactory);
+    }
+
+    @Bean
+    public MessageListenerAdapter listenerAdaptor(RabbitmqAddressRequestReceiver receiver) {
+        return new MessageListenerAdapter(receiver, "receiveAddressRequest");
+    }
+
+    @Bean
+    public SimpleMessageListenerContainer container(ConnectionFactory connectionFactory,
+        MessageListenerAdapter listenerAdapter) {
+        SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        container.setQueueNames(ADDRESS_REQUEST_QUEUE);
+        container.setMessageListener(listenerAdapter);
+        container.setConcurrentConsumers(30);
+        return container;
+    }
+}

--- a/src/main/java/net/catsnap/global/rabbitmq/RabbitmqConfig.java
+++ b/src/main/java/net/catsnap/global/rabbitmq/RabbitmqConfig.java
@@ -2,10 +2,12 @@ package net.catsnap.global.rabbitmq;
 
 import net.catsnap.domain.reservation.rabbitmq.RabbitmqAddressRequestReceiver;
 import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.config.RetryInterceptorBuilder;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
 import org.springframework.amqp.rabbit.listener.adapter.MessageListenerAdapter;
+import org.springframework.amqp.rabbit.retry.RejectAndDontRequeueRecoverer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -37,6 +39,13 @@ public class RabbitmqConfig {
         container.setQueueNames(ADDRESS_REQUEST_QUEUE);
         container.setMessageListener(listenerAdapter);
         container.setConcurrentConsumers(30);
+        container.setAdviceChain(
+            RetryInterceptorBuilder.stateless()
+                .maxAttempts(3)
+                .backOffOptions(1000, 2.0, 10000)
+                .recoverer(new RejectAndDontRequeueRecoverer())
+                .build()
+        );
         return container;
     }
 }

--- a/src/main/java/net/catsnap/global/rabbitmq/RabbitmqConfig.java
+++ b/src/main/java/net/catsnap/global/rabbitmq/RabbitmqConfig.java
@@ -27,7 +27,7 @@ public class RabbitmqConfig {
     }
 
     @Bean
-    public MessageListenerAdapter listenerAdaptor(RabbitmqAddressRequestReceiver receiver) {
+    public MessageListenerAdapter listenerAdapter(RabbitmqAddressRequestReceiver receiver) {
         return new MessageListenerAdapter(receiver, "receiveAddressRequest");
     }
 


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[feat]: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #139 

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->
리팩토링 전 예약시 좌표를 통해 주소 알아내는 API는 동기적으로 호출했습니다.

그러나 해당 API의 응답은 예약 자체에 직접적인 영향을 주지 않는 정보입니다.
따라서 rabbitMQ로 비동기 처리했습니다.

예약 성공 응답 시간이 기존 233ms에서 61ms로 단축되었습니다.