### PR TITLE
[REFACT] 유저 클래스를 구분하는 칼럼명 변경 (#155)

### DIFF
--- a/src/main/java/net/catsnap/domain/user/entity/User.java
+++ b/src/main/java/net/catsnap/domain/user/entity/User.java
@@ -2,7 +2,10 @@ package net.catsnap.domain.user.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.DiscriminatorType;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -26,7 +29,7 @@ import org.springframework.security.core.GrantedAuthority;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
-@DiscriminatorColumn
+@DiscriminatorColumn(name = "user_type", discriminatorType = DiscriminatorType.STRING)
 @DiscriminatorOptions(force = false)
 @Table(name = "users")
 @Getter
@@ -45,6 +48,10 @@ public abstract class User {
     private LocalDate birthday;
     private String phoneNumber;
     private String profilePhotoUrl;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "user_type", insertable = false, updatable = false)
+    private UserType dtype;
 
     @CreatedDate
     @Column(name = "created_at", updatable = false)

--- a/src/main/java/net/catsnap/domain/user/entity/User.java
+++ b/src/main/java/net/catsnap/domain/user/entity/User.java
@@ -51,7 +51,7 @@ public abstract class User {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "user_type", insertable = false, updatable = false)
-    private UserType dtype;
+    private UserType userType;
 
     @CreatedDate
     @Column(name = "created_at", updatable = false)

--- a/src/main/java/net/catsnap/domain/user/entity/UserType.java
+++ b/src/main/java/net/catsnap/domain/user/entity/UserType.java
@@ -1,0 +1,7 @@
+package net.catsnap.domain.user.entity;
+
+public enum UserType {
+    PHOTOGRAPHER, // 사진작가
+    MEMBER, // 일반회원
+    FAKE_USER, // 가짜회원(비회원)
+}

--- a/src/main/java/net/catsnap/domain/user/fakeuser/entity/FakeUser.java
+++ b/src/main/java/net/catsnap/domain/user/fakeuser/entity/FakeUser.java
@@ -1,5 +1,6 @@
 package net.catsnap.domain.user.fakeuser.entity;
 
+import jakarta.persistence.DiscriminatorValue;
 import java.util.Collection;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -12,6 +13,7 @@ import org.springframework.security.core.GrantedAuthority;
 @Getter
 @SuperBuilder
 @AllArgsConstructor
+@DiscriminatorValue("FAKE_USER")
 public class FakeUser extends User {
 
     public static Long fakeUserId = -1L;

--- a/src/main/java/net/catsnap/domain/user/member/entity/Member.java
+++ b/src/main/java/net/catsnap/domain/user/member/entity/Member.java
@@ -1,5 +1,6 @@
 package net.catsnap.domain.user.member.entity;
 
+import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -29,6 +30,7 @@ import org.springframework.security.core.GrantedAuthority;
 @SuperBuilder
 @AllArgsConstructor
 @NoArgsConstructor
+@DiscriminatorValue("MEMBER")
 public class Member extends User {
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/net/catsnap/domain/user/photographer/entity/Photographer.java
+++ b/src/main/java/net/catsnap/domain/user/photographer/entity/Photographer.java
@@ -1,5 +1,6 @@
 package net.catsnap.domain.user.photographer.entity;
 
+import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
@@ -26,6 +27,7 @@ import org.springframework.security.core.GrantedAuthority;
 @SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
+@DiscriminatorValue("PHOTOGRAPHER")
 public class Photographer extends User {
 
     // OneToMany


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[feat]: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #155 

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->
유저 클래스를 구분하는 칼럼명 변경하였습니다.

리팩토링 전 : dtpye
리팩토링 후 : user_type

또한, 해당 데이터가 String이 아닌, enum에 매핑되도록 했습니다.