### PR TITLE
[REFACT] 리뷰 검색에서 작가의 필요한 정보만을 가져오도록 수정 (#154)

### DIFF
--- a/src/main/java/net/catsnap/domain/search/dto/response/LocationSearchResponse.java
+++ b/src/main/java/net/catsnap/domain/search/dto/response/LocationSearchResponse.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import net.catsnap.domain.reservation.dto.ReservationLocation;
 import net.catsnap.domain.review.entity.Review;
+import net.catsnap.domain.user.entity.UserTinyInformation;
 import net.catsnap.domain.user.member.dto.response.MemberTinyInformationResponse;
 import net.catsnap.domain.user.photographer.dto.response.PhotographerTinyInformationResponse;
 
@@ -39,10 +40,11 @@ public record LocationSearchResponse(
     Integer placeScore
 ) {
 
-    public static LocationSearchResponse from(Review review) {
+    public static LocationSearchResponse from(Review review,
+        UserTinyInformation userTinyInformation) {
         return new LocationSearchResponse(
             MemberTinyInformationResponse.from(review.getMember()),
-            PhotographerTinyInformationResponse.from(review.getPhotographer()),
+            PhotographerTinyInformationResponse.from(userTinyInformation),
             review.getId(),
             review.getCreatedAt(),
             review.getReservation().getStartTime(),

--- a/src/main/java/net/catsnap/domain/search/service/LocationSearchService.java
+++ b/src/main/java/net/catsnap/domain/search/service/LocationSearchService.java
@@ -1,5 +1,6 @@
 package net.catsnap.domain.search.service;
 
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import net.catsnap.domain.review.entity.Review;
@@ -7,6 +8,9 @@ import net.catsnap.domain.review.repository.ReviewRepository;
 import net.catsnap.domain.search.dto.request.LocationSearchRequest;
 import net.catsnap.domain.search.dto.response.LocationSearchListResponse;
 import net.catsnap.domain.search.dto.response.LocationSearchResponse;
+import net.catsnap.domain.user.entity.UserTinyInformation;
+import net.catsnap.domain.user.repository.UserTinyInformationRepository;
+import net.catsnap.global.Exception.authority.ResourceNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class LocationSearchService {
 
     private final ReviewRepository reviewRepository;
+    private final UserTinyInformationRepository userTinyInformationRepository;
 
     @Transactional(readOnly = true)
     public LocationSearchListResponse searchLocation(LocationSearchRequest locationSearchRequest) {
@@ -23,10 +28,17 @@ public class LocationSearchService {
         double maxX = locationSearchRequest.BottomRightCoordinate().longitude();
         double maxY = locationSearchRequest.TopLeftCoordinate().latitude();
         List<Review> reviewList = reviewRepository.findAllByLocation(minX, minY, maxX, maxY);
-        return LocationSearchListResponse.from(
-            reviewList.stream()
-                .map(LocationSearchResponse::from)
-                .toList()
-        );
+
+        List<LocationSearchResponse> responseList = new ArrayList<>();
+
+        for (Review review : reviewList) {
+            Long photographerId = review.getReservation().getPhotographer().getId();
+            UserTinyInformation userInfo = userTinyInformationRepository.findById(photographerId)
+                .orElseThrow(() -> new ResourceNotFoundException("작가를 찾을 수 없습니다."));
+            LocationSearchResponse response = LocationSearchResponse.from(review, userInfo);
+            responseList.add(response);
+        }
+
+        return LocationSearchListResponse.from(responseList);
     }
 }

--- a/src/main/java/net/catsnap/domain/user/entity/UserTinyInformation.java
+++ b/src/main/java/net/catsnap/domain/user/entity/UserTinyInformation.java
@@ -27,4 +27,5 @@ public class UserTinyInformation {
 
     private String nickname;
     private String profilePhotoUrl;
+    private UserType userType;
 }

--- a/src/main/java/net/catsnap/domain/user/entity/UserTinyInformation.java
+++ b/src/main/java/net/catsnap/domain/user/entity/UserTinyInformation.java
@@ -1,0 +1,30 @@
+package net.catsnap.domain.user.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Immutable;
+
+
+/*
+ * 해당 엔티티는 유저 조회용 뷰와 매핑된 엔티티입니다.
+ */
+@Entity
+@Immutable
+@Table(name = "user_tiny_information")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserTinyInformation {
+
+    @Id
+    private Long id;
+
+    private String nickname;
+    private String profilePhotoUrl;
+}

--- a/src/main/java/net/catsnap/domain/user/photographer/dto/response/PhotographerTinyInformationResponse.java
+++ b/src/main/java/net/catsnap/domain/user/photographer/dto/response/PhotographerTinyInformationResponse.java
@@ -1,5 +1,6 @@
 package net.catsnap.domain.user.photographer.dto.response;
 
+import net.catsnap.domain.user.entity.UserTinyInformation;
 import net.catsnap.domain.user.photographer.entity.Photographer;
 
 public record PhotographerTinyInformationResponse(
@@ -12,5 +13,12 @@ public record PhotographerTinyInformationResponse(
         return new PhotographerTinyInformationResponse(photographer.getId(),
             photographer.getNickname(),
             photographer.getProfilePhotoUrl());
+    }
+
+    public static PhotographerTinyInformationResponse from(
+        UserTinyInformation userTinyInformation) {
+        return new PhotographerTinyInformationResponse(userTinyInformation.getId(),
+            userTinyInformation.getNickname(),
+            userTinyInformation.getProfilePhotoUrl());
     }
 }

--- a/src/main/java/net/catsnap/domain/user/repository/UserTinyInformationRepository.java
+++ b/src/main/java/net/catsnap/domain/user/repository/UserTinyInformationRepository.java
@@ -1,0 +1,10 @@
+package net.catsnap.domain.user.repository;
+
+import java.util.Optional;
+import net.catsnap.domain.user.entity.UserTinyInformation;
+import org.springframework.data.repository.Repository;
+
+public interface UserTinyInformationRepository extends Repository<UserTinyInformation, Long> {
+
+    Optional<UserTinyInformation> findById(Long id);
+}


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[feat]: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #154 

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->
리뷰 검색에서 작가의 필요한 정보만을 가져오도록 수정하였습니다.

즉, 아이디, 비밀번호 같은 정보를 가져오지 않도록 View 엔티티를 만들어 리뷰 검색에는 불필요한 정보가 서버에 오지 않도록 수정했습니다.