### PR TITLE
[FEAT] 읽지 않은 알람의 수를 조회한는 API 구현 (#174)

### DIFF
--- a/src/main/java/net/catsnap/domain/auth/service/MemberAuthService.java
+++ b/src/main/java/net/catsnap/domain/auth/service/MemberAuthService.java
@@ -1,7 +1,10 @@
 package net.catsnap.domain.auth.service;
 
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import net.catsnap.domain.auth.dto.member.request.MemberSignUpRequest;
+import net.catsnap.domain.notification.entity.NotificationLastRead;
+import net.catsnap.domain.notification.repository.NotificationLastReadRepository;
 import net.catsnap.domain.user.member.entity.Member;
 import net.catsnap.domain.user.member.repository.MemberRepository;
 import net.catsnap.domain.user.repository.UserRepository;
@@ -17,6 +20,7 @@ public class MemberAuthService {
     private final UserRepository userRepository;
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
+    private final NotificationLastReadRepository notificationLastReadRepository;
 
     @Transactional
     public void singUp(MemberSignUpRequest memberSignUpRequest) {
@@ -28,6 +32,12 @@ public class MemberAuthService {
         Member singUpMember = memberSignUpRequest.toEntity(hashedPassword);
         memberRepository.save(singUpMember);
         //todo 멤버 약관 동의 상태 저장
+
+        NotificationLastRead notificationLastRead = NotificationLastRead.builder().
+            user(singUpMember)
+            .lastReadAt(LocalDateTime.now())
+            .build();
+        notificationLastReadRepository.save(notificationLastRead);
     }
 
     //약관 동의 상태와 필수 약관 동의 여부 확인

--- a/src/main/java/net/catsnap/domain/auth/service/PhotographerAuthService.java
+++ b/src/main/java/net/catsnap/domain/auth/service/PhotographerAuthService.java
@@ -1,7 +1,10 @@
 package net.catsnap.domain.auth.service;
 
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import net.catsnap.domain.auth.dto.photographer.request.PhotographerSignUpRequest;
+import net.catsnap.domain.notification.entity.NotificationLastRead;
+import net.catsnap.domain.notification.repository.NotificationLastReadRepository;
 import net.catsnap.domain.reservation.service.PhotographerReservationService;
 import net.catsnap.domain.user.photographer.document.PhotographerSetting;
 import net.catsnap.domain.user.photographer.entity.Photographer;
@@ -26,6 +29,7 @@ public class PhotographerAuthService {
     private final PhotographerSettingRepository photographerSettingRepository;
     private final PhotographerReservationNoticeRepository photographerReservationNoticeRepository;
     private final PhotographerReservationLocationRepository photographerReservationLocationRepository;
+    private final NotificationLastReadRepository notificationLastReadRepository;
 
     private final PhotographerReservationService photographerReservationService;
     private final PhotographerIntroductionService photographerIntroductionService;
@@ -67,5 +71,12 @@ public class PhotographerAuthService {
 
         Photographer photographer = photographerRepository.getReferenceById(photographerId);
         photographerIntroductionService.initPhotographerIntroduction(photographer);
+
+        // 알림 마지막 읽은 시간 초기화
+        NotificationLastRead notificationLastRead = NotificationLastRead.builder().
+            user(photographer)
+            .lastReadAt(LocalDateTime.now())
+            .build();
+        notificationLastReadRepository.save(notificationLastRead);
     }
 }

--- a/src/main/java/net/catsnap/domain/notification/controller/NotificationController.java
+++ b/src/main/java/net/catsnap/domain/notification/controller/NotificationController.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import net.catsnap.domain.auth.argumentresolver.UserId;
 import net.catsnap.domain.auth.interceptor.LoginUser;
 import net.catsnap.domain.notification.dto.response.NotificationListResponse;
+import net.catsnap.domain.notification.dto.response.NotificationUnReadCountResponse;
 import net.catsnap.domain.notification.service.NotificationReadService;
 import net.catsnap.global.result.ResultResponse;
 import net.catsnap.global.result.SlicedData;
@@ -73,17 +74,20 @@ public class NotificationController {
             notificationListResponseSlicedData);
     }
 
-    @Operation(summary = "읽지 않은 알림의 수를 조회하는 API", description = "읽지 않은 알림의 수를 조회하는 API입니다.")
+    @Operation(summary = "읽지 않은 알림의 수를 조회하는 API(구현완료)", description = "읽지 않은 알림의 수를 조회하는 API입니다.")
     @ApiResponses({
         @ApiResponse(responseCode = "200 SC000", description = "성공적으로 데이터를 조회했습니다."),
     })
     @LoginUser
     @GetMapping("/unread-count")
-    public ResponseEntity<ResultResponse<?>> getUnreadNotificationCount(
+    public ResponseEntity<ResultResponse<NotificationUnReadCountResponse>> getUnreadNotificationCount(
         @UserId
         Long userId
     ) {
-        return null;
+        NotificationUnReadCountResponse notificationUnReadCountResponse
+            = notificationReadService.getNotificationUnReadCount(userId);
+        return ResultResponse.of(CommonResultCode.COMMON_LOOK_UP,
+            notificationUnReadCountResponse);
     }
 
 

--- a/src/main/java/net/catsnap/domain/notification/controller/NotificationController.java
+++ b/src/main/java/net/catsnap/domain/notification/controller/NotificationController.java
@@ -73,6 +73,19 @@ public class NotificationController {
             notificationListResponseSlicedData);
     }
 
+    @Operation(summary = "읽지 않은 알림의 수를 조회하는 API", description = "읽지 않은 알림의 수를 조회하는 API입니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200 SC000", description = "성공적으로 데이터를 조회했습니다."),
+    })
+    @LoginUser
+    @GetMapping("/unread-count")
+    public ResponseEntity<ResultResponse<?>> getUnreadNotificationCount(
+        @UserId
+        Long userId
+    ) {
+        return null;
+    }
+
 
     @Operation(summary = "알림을 삭제하는 API", description = "알림을 삭제하는 API입니다.")
     @ApiResponses({

--- a/src/main/java/net/catsnap/domain/notification/dto/response/NotificationUnReadCountResponse.java
+++ b/src/main/java/net/catsnap/domain/notification/dto/response/NotificationUnReadCountResponse.java
@@ -1,0 +1,10 @@
+package net.catsnap.domain.notification.dto.response;
+
+public record NotificationUnReadCountResponse(
+    Long notificationUnReadCount
+) {
+
+    public static NotificationUnReadCountResponse of(Long notificationUnReadCount) {
+        return new NotificationUnReadCountResponse(notificationUnReadCount);
+    }
+}

--- a/src/main/java/net/catsnap/domain/notification/entity/NotificationLastRead.java
+++ b/src/main/java/net/catsnap/domain/notification/entity/NotificationLastRead.java
@@ -33,4 +33,8 @@ public class NotificationLastRead {
     private User user;
 
     private LocalDateTime lastReadAt;
+
+    public void updateLastReadAt(LocalDateTime lastReadAt) {
+        this.lastReadAt = lastReadAt;
+    }
 }

--- a/src/main/java/net/catsnap/domain/notification/entity/NotificationLastRead.java
+++ b/src/main/java/net/catsnap/domain/notification/entity/NotificationLastRead.java
@@ -1,0 +1,36 @@
+package net.catsnap.domain.notification.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import net.catsnap.domain.user.entity.User;
+
+@Entity
+@Table(name = "notification_last_read")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationLastRead {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_last_read_id")
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private LocalDateTime lastReadAt;
+}

--- a/src/main/java/net/catsnap/domain/notification/repository/NotificationLastReadRepository.java
+++ b/src/main/java/net/catsnap/domain/notification/repository/NotificationLastReadRepository.java
@@ -1,5 +1,6 @@
 package net.catsnap.domain.notification.repository;
 
+import java.util.Optional;
 import net.catsnap.domain.notification.entity.NotificationLastRead;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -7,4 +8,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface NotificationLastReadRepository extends JpaRepository<NotificationLastRead, Long> {
 
+    Optional<NotificationLastRead> findByUserId(Long userId);
 }

--- a/src/main/java/net/catsnap/domain/notification/repository/NotificationLastReadRepository.java
+++ b/src/main/java/net/catsnap/domain/notification/repository/NotificationLastReadRepository.java
@@ -1,0 +1,10 @@
+package net.catsnap.domain.notification.repository;
+
+import net.catsnap.domain.notification.entity.NotificationLastRead;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NotificationLastReadRepository extends JpaRepository<NotificationLastRead, Long> {
+
+}

--- a/src/main/java/net/catsnap/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/net/catsnap/domain/notification/repository/NotificationRepository.java
@@ -24,4 +24,6 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     void updateReadAtAfter(@Param("readAt") LocalDateTime readAt,
         @Param("receiverId") Long receiverId,
         @Param("lastReadAt") LocalDateTime lastReadAt);
+
+    Long countByReceiverIdAndReadAtIsNull(Long receiverId);
 }

--- a/src/main/java/net/catsnap/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/net/catsnap/domain/notification/repository/NotificationRepository.java
@@ -5,6 +5,9 @@ import net.catsnap.domain.notification.entity.Notification;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -15,4 +18,10 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     Slice<Notification> findByReceiverAndCreatedAtBefore(Long receiverId,
         LocalDateTime createdAt, Pageable pageable);
+
+    @Modifying
+    @Query("UPDATE Notification n SET n.readAt = :readAt WHERE n.receiver.id = :receiverId AND n.createdAt > :lastReadAt")
+    void updateReadAtAfter(@Param("readAt") LocalDateTime readAt,
+        @Param("receiverId") Long receiverId,
+        @Param("lastReadAt") LocalDateTime lastReadAt);
 }

--- a/src/main/java/net/catsnap/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/net/catsnap/domain/notification/repository/NotificationRepository.java
@@ -13,10 +13,10 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
-    Slice<Notification> findByReceiverAndCreatedAtAfter(Long receiverId,
+    Slice<Notification> findByReceiverIdAndCreatedAtAfter(Long receiverId,
         LocalDateTime createdAt, Pageable pageable);
 
-    Slice<Notification> findByReceiverAndCreatedAtBefore(Long receiverId,
+    Slice<Notification> findByReceiverIdAndCreatedAtBefore(Long receiverId,
         LocalDateTime createdAt, Pageable pageable);
 
     @Modifying

--- a/src/main/java/net/catsnap/domain/notification/service/NotificationReadService.java
+++ b/src/main/java/net/catsnap/domain/notification/service/NotificationReadService.java
@@ -26,7 +26,7 @@ public class NotificationReadService {
     public SlicedData<NotificationListResponse> getRecentNotification(Long userId,
         Pageable pageable, LocalDateTime from) {
         readNotification(userId);
-        Slice<Notification> notificationSlice = notificationRepository.findByReceiverAndCreatedAtAfter(
+        Slice<Notification> notificationSlice = notificationRepository.findByReceiverIdAndCreatedAtAfter(
             userId, from, pageable);
         List<NotificationResponse> notificationResponseList = notificationSlice.getContent()
             .stream()
@@ -39,7 +39,7 @@ public class NotificationReadService {
 
     public SlicedData<NotificationListResponse> getOldNotification(Long userId,
         Pageable pageable, LocalDateTime to) {
-        Slice<Notification> notificationSlice = notificationRepository.findByReceiverAndCreatedAtBefore(
+        Slice<Notification> notificationSlice = notificationRepository.findByReceiverIdAndCreatedAtBefore(
             userId, to, pageable);
         List<NotificationResponse> notificationResponseList = notificationSlice.getContent()
             .stream()

--- a/src/main/java/net/catsnap/domain/notification/service/NotificationReadService.java
+++ b/src/main/java/net/catsnap/domain/notification/service/NotificationReadService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import net.catsnap.domain.notification.dto.response.NotificationListResponse;
 import net.catsnap.domain.notification.dto.response.NotificationResponse;
+import net.catsnap.domain.notification.dto.response.NotificationUnReadCountResponse;
 import net.catsnap.domain.notification.entity.Notification;
 import net.catsnap.domain.notification.entity.NotificationLastRead;
 import net.catsnap.domain.notification.repository.NotificationLastReadRepository;
@@ -47,6 +48,12 @@ public class NotificationReadService {
         return SlicedData.of(NotificationListResponse.from(notificationResponseList),
             notificationSlice.isFirst(),
             notificationSlice.isLast());
+    }
+
+    public NotificationUnReadCountResponse getNotificationUnReadCount(Long userId) {
+        Long notificationUnReadCount = notificationRepository.countByReceiverIdAndReadAtIsNull(
+            userId);
+        return NotificationUnReadCountResponse.of(notificationUnReadCount);
     }
 
     private void readNotification(Long userId) {

--- a/src/main/java/net/catsnap/domain/notification/service/NotificationReadService.java
+++ b/src/main/java/net/catsnap/domain/notification/service/NotificationReadService.java
@@ -6,7 +6,10 @@ import lombok.RequiredArgsConstructor;
 import net.catsnap.domain.notification.dto.response.NotificationListResponse;
 import net.catsnap.domain.notification.dto.response.NotificationResponse;
 import net.catsnap.domain.notification.entity.Notification;
+import net.catsnap.domain.notification.entity.NotificationLastRead;
+import net.catsnap.domain.notification.repository.NotificationLastReadRepository;
 import net.catsnap.domain.notification.repository.NotificationRepository;
+import net.catsnap.global.Exception.authority.OwnershipNotFoundException;
 import net.catsnap.global.result.SlicedData;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -17,9 +20,11 @@ import org.springframework.stereotype.Service;
 public class NotificationReadService {
 
     private final NotificationRepository notificationRepository;
+    private final NotificationLastReadRepository notificationLastReadRepository;
 
     public SlicedData<NotificationListResponse> getRecentNotification(Long userId,
         Pageable pageable, LocalDateTime from) {
+        readNotification(userId);
         Slice<Notification> notificationSlice = notificationRepository.findByReceiverAndCreatedAtAfter(
             userId, from, pageable);
         List<NotificationResponse> notificationResponseList = notificationSlice.getContent()
@@ -42,5 +47,27 @@ public class NotificationReadService {
         return SlicedData.of(NotificationListResponse.from(notificationResponseList),
             notificationSlice.isFirst(),
             notificationSlice.isLast());
+    }
+
+    private void readNotification(Long userId) {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime lastReadAt = notificationLastReadRepository.findByUserId(userId)
+            .map(NotificationLastRead::getLastReadAt)
+            .orElse(now);
+        notificationRepository.updateReadAtAfter(now, userId, lastReadAt);
+        updateReadNotificationTime(userId, now);
+    }
+
+    private void updateReadNotificationTime(Long userId, LocalDateTime now) {
+        notificationLastReadRepository.findByUserId(userId)
+            .ifPresentOrElse(
+                notificationLastRead -> {
+                    notificationLastRead.updateLastReadAt(now);
+                    notificationLastReadRepository.save(notificationLastRead);
+                },
+                () -> {
+                    throw new OwnershipNotFoundException("해당 유저의 알림 읽음 시간이 없습니다.");
+                }
+            );
     }
 }

--- a/src/main/resources/db/migration/V0_0_8__add_notification_last_read.sql
+++ b/src/main/resources/db/migration/V0_0_8__add_notification_last_read.sql
@@ -1,0 +1,8 @@
+CREATE TABLE notification_last_read
+(
+    notification_last_read_id BIGSERIAL PRIMARY KEY,
+    user_id                   BIGINT UNIQUE,
+    last_read                 TIMESTAMP(6) NOT NULL,
+    CONSTRAINT fk_notification_last_read__user
+        FOREIGN KEY (user_id) REFERENCES users (id)
+);


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[feat]: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #174 

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->
 읽지 않은 알람의 수를 조회한는 API 구현했습니다.
알림 테이블이 파티셔닝 되어 있기 때문에 마지막에 읽은 알림를 참조하여 조회합니다.