### PR TITLE
[REFACT] 서비스단에서 시큐리티 컨텍스트 의존성 제거 (#195)

### DIFF
--- a/src/main/java/net/catsnap/domain/reservation/controller/MemberReservationController.java
+++ b/src/main/java/net/catsnap/domain/reservation/controller/MemberReservationController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import lombok.RequiredArgsConstructor;
+import net.catsnap.domain.auth.argumentresolver.UserId;
 import net.catsnap.domain.auth.interceptor.AnyUser;
 import net.catsnap.domain.auth.interceptor.LoginMember;
 import net.catsnap.domain.reservation.dto.MonthReservationCheckListResponse;
@@ -51,9 +52,11 @@ public class MemberReservationController {
         @Parameter(description = "ALL : 내 모든 예약(정렬 : 최근 예약한 시간 느릴수록 먼저옴) UPCOMING : 미래에 시작하는 예약(정렬 : 미래 예약 중 현재와 가까운 것이 먼저옴. 예약의 상태가 PENDING, APPROVED 인 것만 보여줌) ")
         @RequestParam("type")
         ReservationQueryType reservationQueryType,
+        @UserId
+        Long memberId,
         Pageable pageable) {
         SlicedData<MemberReservationInformationListResponse> memberReservationInformationList = memberReservationService.getMyReservation(
-            reservationQueryType, pageable);
+            reservationQueryType, pageable, memberId);
 
         return ResultResponse.of(ReservationResultCode.RESERVATION_LOOK_UP,
             memberReservationInformationList);
@@ -69,10 +72,12 @@ public class MemberReservationController {
         @Parameter(description = "조회하고 싶은 달", example = "yyyy-MM")
         @RequestParam("month")
         @DateTimeFormat(pattern = "yyyy-MM")
-        YearMonth reservationMonth
+        YearMonth reservationMonth,
+        @UserId
+        Long memberId
     ) {
         MonthReservationCheckListResponse monthReservationCheckListResponse = memberReservationService.getReservationListByMonth(
-            reservationMonth.atDay(1));
+            reservationMonth.atDay(1), memberId);
         return ResultResponse.of(ReservationResultCode.RESERVATION_LOOK_UP,
             monthReservationCheckListResponse);
     }
@@ -87,10 +92,12 @@ public class MemberReservationController {
         @Parameter(description = "조회하고 싶은 일", example = "yyyy-MM-dd")
         @RequestParam("day")
         @JsonFormat(pattern = "yyyy-MM-dd")
-        LocalDate reservationDay
+        LocalDate reservationDay,
+        @UserId
+        Long memberId
     ) {
         MemberReservationInformationListResponse memberReservationInformationListResponse = memberReservationService.getReservationDetailListByDay(
-            reservationDay);
+            reservationDay, memberId);
         return ResultResponse.of(ReservationResultCode.RESERVATION_LOOK_UP,
             memberReservationInformationListResponse);
     }
@@ -127,10 +134,12 @@ public class MemberReservationController {
     public ResponseEntity<ResultResponse<ReservationBookResultResponse>> postBookReservation(
         @Parameter(description = "새로운 예약 형식")
         @RequestBody
-        MemberReservationRequest memberReservationRequest
+        MemberReservationRequest memberReservationRequest,
+        @UserId
+        Long memberId
     ) {
         ReservationBookResultResponse reservationBookResultResponse = memberReservationFacade.createReservation(
-            memberReservationRequest);
+            memberReservationRequest, memberId);
         return ResultResponse.of(ReservationResultCode.RESERVATION_BOOK_COMPLETE,
             reservationBookResultResponse);
     }

--- a/src/main/java/net/catsnap/domain/reservation/controller/PhotographerReservationController.java
+++ b/src/main/java/net/catsnap/domain/reservation/controller/PhotographerReservationController.java
@@ -47,10 +47,12 @@ public class PhotographerReservationController {
     public ResponseEntity<ResultResponse<MonthReservationCheckListResponse>> getMyMonthReservationCheck(
         @Parameter(description = "조회하고 싶은 달", example = "yyyy-MM")
         @RequestParam("month")
-        YearMonth reservationMonth
+        YearMonth reservationMonth,
+        @UserId
+        Long photographerId
     ) {
         MonthReservationCheckListResponse monthReservationCheckListResponse = photographerReservationService.getReservationListByMonth(
-            reservationMonth.atDay(1));
+            reservationMonth.atDay(1), photographerId);
         return ResultResponse.of(ReservationResultCode.RESERVATION_LOOK_UP,
             monthReservationCheckListResponse);
     }
@@ -65,10 +67,12 @@ public class PhotographerReservationController {
     public ResponseEntity<ResultResponse<PhotographerReservationInformationListResponse>> getMyDayReservation(
         @Parameter(description = "조회하고 싶은 일", example = "yyyy-MM-dd")
         @RequestParam("day")
-        LocalDate reservationDay
+        LocalDate reservationDay,
+        @UserId
+        Long photographerId
     ) {
         PhotographerReservationInformationListResponse photographerReservationInformationListResponse = photographerReservationService.getReservationDetailListByDay(
-            reservationDay);
+            reservationDay, photographerId);
         return ResultResponse.of(ReservationResultCode.RESERVATION_LOOK_UP,
             photographerReservationInformationListResponse);
     }
@@ -109,9 +113,12 @@ public class PhotographerReservationController {
         long reservationId,
         @Parameter(description = "변경하고자 하는 최종 상태", required = true)
         @RequestParam("status")
-        ReservationState status
+        ReservationState status,
+        @UserId
+        Long photographerId
     ) {
-        photographerReservationService.changeReservationState(reservationId, status);
+        photographerReservationService.changeReservationState(reservationId, status,
+            photographerId);
         return ResultResponse.of(ReservationResultCode.PHOTOGRAPHER_RESERVATION_STATE_CHANGE);
     }
 }

--- a/src/main/java/net/catsnap/domain/reservation/controller/ProgramController.java
+++ b/src/main/java/net/catsnap/domain/reservation/controller/ProgramController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import net.catsnap.domain.auth.argumentresolver.UserId;
 import net.catsnap.domain.auth.interceptor.AnyUser;
 import net.catsnap.domain.auth.interceptor.LoginPhotographer;
 import net.catsnap.domain.reservation.dto.PhotographerProgramListResponse;
@@ -65,10 +66,12 @@ public class ProgramController {
         ProgramRequest programRequest,
         @Parameter(description = "예약 프로그램의 id, 수정을 할 때만 입력", required = false)
         @RequestParam(name = "programId", required = false)
-        Long programId
+        Long programId,
+        @UserId
+        Long photographerId
     ) {
         photographerProgramIdResponse photographerProgramIdResponse = programService.createProgram(
-            programRequest, programId);
+            programRequest, programId, photographerId);
         return ResultResponse.of(ReservationResultCode.PHOTOGRAPHER_POST_PROGRAM,
             photographerProgramIdResponse);
     }
@@ -82,8 +85,12 @@ public class ProgramController {
     )
     @GetMapping("/photographer/my/program")
     @LoginPhotographer
-    public ResponseEntity<ResultResponse<PhotographerProgramListResponse>> getProgram() {
-        PhotographerProgramListResponse photographerProgramListResponse = programService.getMyProgramList();
+    public ResponseEntity<ResultResponse<PhotographerProgramListResponse>> getProgram(
+        @UserId
+        Long photographerId
+    ) {
+        PhotographerProgramListResponse photographerProgramListResponse = programService.getMyProgramList(
+            photographerId);
         return ResultResponse.of(ReservationResultCode.PHOTOGRAPHER_LOOK_UP_PROGRAM,
             photographerProgramListResponse);
     }
@@ -101,9 +108,11 @@ public class ProgramController {
     public ResponseEntity<ResultResponse<ReservationResultCode>> deleteProgram(
         @Parameter(description = "삭제하고자 하는 예약 프로그램의 id", required = true)
         @RequestParam("programId")
-        Long programId
+        Long programId,
+        @UserId
+        Long photographerId
     ) {
-        programService.softDeleteProgram(programId);
+        programService.softDeleteProgram(programId, photographerId);
         return ResultResponse.of(ReservationResultCode.PHOTOGRAPHER_DELETE_PROGRAM);
     }
 }

--- a/src/main/java/net/catsnap/domain/reservation/controller/ReservationTimeController.java
+++ b/src/main/java/net/catsnap/domain/reservation/controller/ReservationTimeController.java
@@ -78,10 +78,12 @@ public class ReservationTimeController {
         ReservationTimeFormatRequest reservationTimeFormatRequest,
         @Parameter(description = "예약 시간 형식의 이름", required = false)
         @RequestParam(name = "timeFormatId", required = false)
-        String timeFormatId
+        String timeFormatId,
+        @UserId
+        Long photographerId
     ) {
         ReservationTimeFormatIdResponse reservationTimeFormatIdResponse = reservationTimeService.createReservationTimeFormat(
-            reservationTimeFormatRequest, timeFormatId);
+            reservationTimeFormatRequest, timeFormatId, photographerId);
         return ResultResponse.of(ReservationResultCode.PHOTOGRAPHER_RESERVATION_TIME_FORMAT,
             reservationTimeFormatIdResponse);
     }
@@ -95,8 +97,12 @@ public class ReservationTimeController {
     )
     @GetMapping("/my/timeformat")
     @LoginPhotographer
-    public ResponseEntity<ResultResponse<ReservationTimeFormatListResponse>> getTimeFormat() {
-        ReservationTimeFormatListResponse reservationTimeFormatList = reservationTimeService.getMyReservationTimeFormatList();
+    public ResponseEntity<ResultResponse<ReservationTimeFormatListResponse>> getTimeFormat(
+        @UserId
+        Long photographerId
+    ) {
+        ReservationTimeFormatListResponse reservationTimeFormatList = reservationTimeService.getMyReservationTimeFormatList(
+            photographerId);
         return ResultResponse.of(ReservationResultCode.PHOTOGRAPHER_RESERVATION_TIME_FORMAT_LOOK_UP,
             reservationTimeFormatList);
     }
@@ -116,9 +122,11 @@ public class ReservationTimeController {
     public ResponseEntity<ResultResponse<ReservationResultCode>> deleteTimeFormat(
         @Parameter(description = "삭제하고자 하는 예약 시간 형식의 id", required = true)
         @RequestParam("timeFormatId")
-        String timeFormatId
+        String timeFormatId,
+        @UserId
+        Long photographerId
     ) {
-        reservationTimeService.deleteReservationTimeFormat(timeFormatId);
+        reservationTimeService.deleteReservationTimeFormat(timeFormatId, photographerId);
         return ResultResponse.of(ReservationResultCode.PHOTOGRAPHER_RESERVATION_TIME_FORMAT_DELETE);
     }
 
@@ -142,9 +150,12 @@ public class ReservationTimeController {
         Weekday weekday,
         @Parameter(description = "등록하고자 하는 예약 시간 형식의 id", required = true)
         @RequestParam("timeFormatId")
-        String timeFormatId
+        String timeFormatId,
+        @UserId
+        Long photographerId
     ) {
-        reservationTimeService.mappingWeekdayToReservationTimeFormat(timeFormatId, weekday);
+        reservationTimeService.mappingWeekdayToReservationTimeFormat(timeFormatId, weekday,
+            photographerId);
         return ResultResponse.of(
             ReservationResultCode.PHOTOGRAPHER_RESERVATION_TIME_FORMAT_MAPPING_WEEKDAY);
     }
@@ -165,9 +176,12 @@ public class ReservationTimeController {
             "MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY, HOLIDAY 중 1개의 값",
             required = true)
         @RequestParam("weekday")
-        Weekday weekday
+        Weekday weekday,
+        @UserId
+        Long photographerId
     ) {
-        reservationTimeService.unmappingWeekdayToReservationTimeFormatByWeekday(weekday);
+        reservationTimeService.unmappingWeekdayToReservationTimeFormatByWeekday(weekday,
+            photographerId);
         return ResultResponse.of(
             ReservationResultCode.PHOTOGRAPHER_RESERVATION_TIME_FORMAT_UNMAPPING_WEEKDAY);
     }

--- a/src/main/java/net/catsnap/domain/reservation/service/MemberReservationFacade.java
+++ b/src/main/java/net/catsnap/domain/reservation/service/MemberReservationFacade.java
@@ -16,10 +16,10 @@ public class MemberReservationFacade {
 
 
     public ReservationBookResultResponse createReservation(
-        MemberReservationRequest memberReservationRequest) {
+        MemberReservationRequest memberReservationRequest, Long memberId) {
 
         Reservation reservation = memberReservationService.createReservation(
-            memberReservationRequest);
+            memberReservationRequest, memberId);
         addressRequestSender.sendRequestAddress(reservation.getId());
         return ReservationBookResultResponse.from(reservation);
     }

--- a/src/main/java/net/catsnap/domain/reservation/service/MemberReservationService.java
+++ b/src/main/java/net/catsnap/domain/reservation/service/MemberReservationService.java
@@ -33,7 +33,6 @@ import net.catsnap.global.Exception.reservation.NotFoundStartTimeException;
 import net.catsnap.global.Exception.reservation.OverLappingTimeException;
 import net.catsnap.global.geography.converter.GeographyConverter;
 import net.catsnap.global.result.SlicedData;
-import net.catsnap.global.security.contextholder.GetAuthenticationInfo;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -55,8 +54,7 @@ public class MemberReservationService {
     private final ReservationValidatorService reservationValidatorService;
 
     public Reservation createReservation(
-        MemberReservationRequest memberReservationRequest) {
-        Long memberId = GetAuthenticationInfo.getUserId();
+        MemberReservationRequest memberReservationRequest, long memberId) {
         PhotographerSetting photographerSetting = photographerService.findPhotographerSetting(
             memberReservationRequest.photographerId());
         Program program = programRepository.findById(
@@ -135,8 +133,7 @@ public class MemberReservationService {
 
     public SlicedData<MemberReservationInformationListResponse> getMyReservation(
         ReservationQueryType reservationQueryType,
-        Pageable pageable) {
-        Long memberId = GetAuthenticationInfo.getUserId();
+        Pageable pageable, long memberId) {
         Slice<Reservation> reservationSlice = null;
 
         if (reservationQueryType.equals(ReservationQueryType.ALL)) {
@@ -162,8 +159,8 @@ public class MemberReservationService {
             reservationSlice.isLast());
     }
 
-    public MonthReservationCheckListResponse getReservationListByMonth(LocalDate month) {
-        Long memberId = GetAuthenticationInfo.getUserId();
+    public MonthReservationCheckListResponse getReservationListByMonth(LocalDate month,
+        long memberId) {
         LocalDateTime startOfMonth = LocalDateTime.of(month.getYear(), month.getMonthValue(), 1, 0,
             0, 0);
         LocalDateTime endOfMonth = LocalDateTime.of(month.getYear(), month.getMonthValue(),
@@ -181,8 +178,7 @@ public class MemberReservationService {
     }
 
     public MemberReservationInformationListResponse getReservationDetailListByDay(
-        LocalDate day) {
-        Long memberId = GetAuthenticationInfo.getUserId();
+        LocalDate day, long memberId) {
         LocalDateTime startOfDay = LocalDateTime.of(day.getYear(), day.getMonthValue(),
             day.getDayOfMonth(), 0, 0, 0);
         LocalDateTime endOfDay = LocalDateTime.of(day.getYear(), day.getMonthValue(),

--- a/src/main/java/net/catsnap/domain/reservation/service/PhotographerReservationService.java
+++ b/src/main/java/net/catsnap/domain/reservation/service/PhotographerReservationService.java
@@ -20,7 +20,6 @@ import net.catsnap.domain.user.photographer.entity.Photographer;
 import net.catsnap.global.Exception.authority.ResourceNotFoundException;
 import net.catsnap.global.Exception.reservation.CanNotChangeReservationState;
 import net.catsnap.global.result.SlicedData;
-import net.catsnap.global.security.contextholder.GetAuthenticationInfo;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -53,8 +52,8 @@ public class PhotographerReservationService {
         weekdayReservationTimeMappingRepository.saveAll(weekdayReservationTimeMappingList);
     }
 
-    public MonthReservationCheckListResponse getReservationListByMonth(LocalDate month) {
-        Long photographerId = GetAuthenticationInfo.getUserId();
+    public MonthReservationCheckListResponse getReservationListByMonth(LocalDate month,
+        long photographerId) {
         LocalDateTime startOfMonth = LocalDateTime.of(month.getYear(), month.getMonthValue(), 1, 0,
             0, 0);
         LocalDateTime endOfMonth = LocalDateTime.of(month.getYear(), month.getMonthValue(),
@@ -71,8 +70,7 @@ public class PhotographerReservationService {
     }
 
     public PhotographerReservationInformationListResponse getReservationDetailListByDay(
-        LocalDate day) {
-        Long photographerId = GetAuthenticationInfo.getUserId();
+        LocalDate day, long photographerId) {
         LocalDateTime startOfDay = LocalDateTime.of(day.getYear(), day.getMonthValue(),
             day.getDayOfMonth(), 0, 0, 0);
         LocalDateTime endOfDay = LocalDateTime.of(day.getYear(), day.getMonthValue(),
@@ -109,8 +107,8 @@ public class PhotographerReservationService {
      * 작가가 예약을 바꿀 수 있는 경우는 아래와 같다.
      * (PENDING -> APPROVED) (PENDING -> REJECTED) (APPROVED -> PHOTOGRAPHY_CANCELLED)
      */
-    public void changeReservationState(Long reservationId, ReservationState reservationState) {
-        Long photographerId = GetAuthenticationInfo.getUserId();
+    public void changeReservationState(Long reservationId, ReservationState reservationState,
+        long photographerId) {
         reservationRepository.findById(reservationId)
             .ifPresentOrElse(reservation -> {
                 reservation.checkPhotographerOwnership(photographerId);

--- a/src/main/java/net/catsnap/domain/reservation/service/ReservationTimeService.java
+++ b/src/main/java/net/catsnap/domain/reservation/service/ReservationTimeService.java
@@ -29,7 +29,6 @@ import net.catsnap.domain.user.photographer.entity.Photographer;
 import net.catsnap.domain.user.photographer.repository.PhotographerRepository;
 import net.catsnap.global.Exception.authority.OwnershipNotFoundException;
 import net.catsnap.global.Exception.authority.ResourceNotFoundException;
-import net.catsnap.global.security.contextholder.GetAuthenticationInfo;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -92,9 +91,9 @@ public class ReservationTimeService {
     }
 
     public ReservationTimeFormatIdResponse createReservationTimeFormat(
-        ReservationTimeFormatRequest reservationTimeFormatRequest, String reservationTimeFormatId) {
+        ReservationTimeFormatRequest reservationTimeFormatRequest, String reservationTimeFormatId,
+        long photographerId) {
 
-        Long photographerId = GetAuthenticationInfo.getUserId();
         ReservationTimeFormat reservationTimeFormat = null;
 
         /*
@@ -116,8 +115,7 @@ public class ReservationTimeService {
         return ReservationTimeFormatIdResponse.from(reservationTimeFormat);
     }
 
-    public ReservationTimeFormatListResponse getMyReservationTimeFormatList() {
-        Long photographerId = GetAuthenticationInfo.getUserId();
+    public ReservationTimeFormatListResponse getMyReservationTimeFormatList(long photographerId) {
         List<ReservationTimeFormat> reservationTimeFormatList = reservationTimeFormatRepository.findByPhotographerId(
             photographerId);
         return ReservationTimeFormatListResponse.from(
@@ -126,8 +124,7 @@ public class ReservationTimeService {
                 .toList());
     }
 
-    public void deleteReservationTimeFormat(String reservationTimeFormatId) {
-        Long photographerId = GetAuthenticationInfo.getUserId();
+    public void deleteReservationTimeFormat(String reservationTimeFormatId, long photographerId) {
         Photographer photographer = photographerRepository.getReferenceById(photographerId);
         DeleteResult deleteResult = reservationTimeFormatRepository.deleteById(
             reservationTimeFormatId, photographerId);
@@ -146,8 +143,7 @@ public class ReservationTimeService {
      * 요일을 예약 시간 형식에 매핑시킨다. (요일을 고정. 예약 시간을 요일에 매핑시키는 것이다.)
      */
     public void mappingWeekdayToReservationTimeFormat(String reservationTimeFormatId,
-        Weekday weekday) {
-        Long photographerId = GetAuthenticationInfo.getUserId();
+        Weekday weekday, Long photographerId) {
         weekdayReservationTimeMappingRepository.findByPhotographerIdAndWeekday(photographerId,
                 weekday)
             .ifPresentOrElse(mapping ->
@@ -164,8 +160,8 @@ public class ReservationTimeService {
             );
     }
 
-    public void unmappingWeekdayToReservationTimeFormatByWeekday(Weekday weekday) {
-        Long photographerId = GetAuthenticationInfo.getUserId();
+    public void unmappingWeekdayToReservationTimeFormatByWeekday(Weekday weekday,
+        long photographerId) {
         weekdayReservationTimeMappingRepository.findByPhotographerIdAndWeekday(photographerId,
                 weekday)
             .ifPresentOrElse(mapping ->

--- a/src/main/java/net/catsnap/domain/review/controller/ReviewController.java
+++ b/src/main/java/net/catsnap/domain/review/controller/ReviewController.java
@@ -48,9 +48,11 @@ public class ReviewController {
     public ResponseEntity<ResultResponse<ReviewPhotoPresignedURLResponse>> postReview(
         @Parameter(description = "새로운 리뷰를 만들 때 작성하는 형식입니다.")
         @RequestBody
-        PostReviewRequest postReviewRequest
+        PostReviewRequest postReviewRequest,
+        @UserId
+        Long memberId
     ) {
-        ReviewPhotoPresignedURLResponse dto = reviewService.postReview(postReviewRequest);
+        ReviewPhotoPresignedURLResponse dto = reviewService.postReview(postReviewRequest, memberId);
         return ResultResponse.of(ReviewResultCode.POST_REVIEW, dto);
     }
 

--- a/src/main/java/net/catsnap/domain/review/service/ReviewService.java
+++ b/src/main/java/net/catsnap/domain/review/service/ReviewService.java
@@ -23,7 +23,6 @@ import net.catsnap.global.aws.s3.ImageDownloadClient;
 import net.catsnap.global.aws.s3.ImageUploadClient;
 import net.catsnap.global.aws.s3.dto.PresignedUrlResponse;
 import net.catsnap.global.result.SlicedData;
-import net.catsnap.global.security.contextholder.GetAuthenticationInfo;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -63,9 +62,8 @@ public class ReviewService {
     }
 
     @Transactional
-    public ReviewPhotoPresignedURLResponse postReview(PostReviewRequest postReviewRequest) {
-        Long memberId = GetAuthenticationInfo.getUserId();
-
+    public ReviewPhotoPresignedURLResponse postReview(PostReviewRequest postReviewRequest,
+        long memberId) {
         // 예약 정보가 있는지 확인
         Reservation reservation = reservationRepository.findById(
                 postReviewRequest.reservationId()

--- a/src/main/java/net/catsnap/domain/user/photographer/controller/PhotographerController.java
+++ b/src/main/java/net/catsnap/domain/user/photographer/controller/PhotographerController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import net.catsnap.domain.auth.argumentresolver.UserId;
 import net.catsnap.domain.auth.interceptor.LoginPhotographer;
 import net.catsnap.domain.user.photographer.converter.PhotographerConverter;
 import net.catsnap.domain.user.photographer.document.PhotographerReservationLocation;
@@ -38,8 +39,12 @@ public class PhotographerController {
     })
     @GetMapping("/my/setting")
     @LoginPhotographer
-    public ResponseEntity<ResultResponse<PhotographerResponse.PhotographerSetting>> lookUpMySetting() {
-        PhotographerSetting photographerSetting = photographerService.getPhotographerSetting();
+    public ResponseEntity<ResultResponse<PhotographerResponse.PhotographerSetting>> lookUpMySetting(
+        @UserId
+        long photographerId
+    ) {
+        PhotographerSetting photographerSetting = photographerService.getPhotographerSetting(
+            photographerId);
         PhotographerResponse.PhotographerSetting photographerSettingDto = photographerConverter.toPhotographerSetting(
             photographerSetting);
         return ResultResponse.of(PhotographerResultCode.LOOK_UP_MY_SETTING, photographerSettingDto);
@@ -54,9 +59,11 @@ public class PhotographerController {
     public ResponseEntity<ResultResponse<PhotographerResultCode>> updateMySetting(
         @Parameter(description = "작가의 환경설정", required = true)
         @RequestBody
-        PhotographerRequest.PhotographerSetting photographerSetting
+        PhotographerRequest.PhotographerSetting photographerSetting,
+        @UserId
+        long photographerId
     ) {
-        photographerService.updatePhotographerSetting(photographerSetting);
+        photographerService.updatePhotographerSetting(photographerSetting, photographerId);
         return ResultResponse.of(PhotographerResultCode.UPDATE_MY_SETTING);
     }
 
@@ -67,8 +74,11 @@ public class PhotographerController {
     @GetMapping("/my/reservation/notice")
     @LoginPhotographer
     public ResponseEntity<ResultResponse<PhotographerResponse.PhotographerReservationNotice>> lookUpMyReservationNotice(
+        @UserId
+        long photographerId
     ) {
-        PhotographerReservationNotice photographerReservationNotice = photographerService.getReservationNotice();
+        PhotographerReservationNotice photographerReservationNotice = photographerService.getReservationNotice(
+            photographerId);
         PhotographerResponse.PhotographerReservationNotice photographerReservationNoticeDto = photographerConverter.toPhotographerReservationNotice(
             photographerReservationNotice);
         return ResultResponse.of(PhotographerResultCode.LOOK_UP_RESERVATION_NOTICE,
@@ -84,9 +94,11 @@ public class PhotographerController {
     public ResponseEntity<ResultResponse<PhotographerResultCode>> updateMyReservationNotice(
         @Parameter(description = "작가의 예약 전 알림", required = true)
         @RequestBody
-        PhotographerRequest.PhotographerReservationNotice photographerReservationNotice
+        PhotographerRequest.PhotographerReservationNotice photographerReservationNotice,
+        @UserId
+        long photographerId
     ) {
-        photographerService.updateReservationNotice(photographerReservationNotice);
+        photographerService.updateReservationNotice(photographerReservationNotice, photographerId);
         return ResultResponse.of(PhotographerResultCode.UPDATE_RESERVATION_NOTICE);
     }
 
@@ -97,8 +109,11 @@ public class PhotographerController {
     @GetMapping("/my/reservation/location")
     @LoginPhotographer
     public ResponseEntity<ResultResponse<PhotographerResponse.PhotographerReservationLocation>> lookUpMyReservationLocation(
+        @UserId
+        long photographerId
     ) {
-        PhotographerReservationLocation photographerReservationLocation = photographerService.getReservationLocation();
+        PhotographerReservationLocation photographerReservationLocation = photographerService.getReservationLocation(
+            photographerId);
         PhotographerResponse.PhotographerReservationLocation photographerReservationLocationDto = photographerConverter.toPhotographerReservationLocation(
             photographerReservationLocation);
         return ResultResponse.of(PhotographerResultCode.LOOK_UP_RESERVATION_LOCATION,
@@ -114,9 +129,12 @@ public class PhotographerController {
     public ResponseEntity<ResultResponse<PhotographerResultCode>> updateMyReservationLocation(
         @Parameter(description = "작가의 예약 전 알림", required = true)
         @RequestBody
-        PhotographerRequest.PhotographerReservationLocation photographerReservationLocation
+        PhotographerRequest.PhotographerReservationLocation photographerReservationLocation,
+        @UserId
+        long photographerId
     ) {
-        photographerService.updateReservationLocation(photographerReservationLocation);
+        photographerService.updateReservationLocation(photographerReservationLocation,
+            photographerId);
         return ResultResponse.of(PhotographerResultCode.UPDATE_RESERVATION_LOCATION);
     }
 }

--- a/src/main/java/net/catsnap/domain/user/photographer/service/PhotographerService.java
+++ b/src/main/java/net/catsnap/domain/user/photographer/service/PhotographerService.java
@@ -9,7 +9,6 @@ import net.catsnap.domain.user.photographer.repository.PhotographerRepository;
 import net.catsnap.domain.user.photographer.repository.PhotographerReservationLocationRepository;
 import net.catsnap.domain.user.photographer.repository.PhotographerReservationNoticeRepository;
 import net.catsnap.domain.user.photographer.repository.PhotographerSettingRepository;
-import net.catsnap.global.security.contextholder.GetAuthenticationInfo;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,14 +22,12 @@ public class PhotographerService {
     private final PhotographerReservationNoticeRepository photographerReservationNoticeRepository;
     private final PhotographerReservationLocationRepository photographerReservationLocationRepository;
 
-    public PhotographerSetting getPhotographerSetting() {
-        Long photographerId = GetAuthenticationInfo.getUserId();
+    public PhotographerSetting getPhotographerSetting(long photographerId) {
         return photographerSettingRepository.findByPhotographerId(photographerId);
     }
 
     public void updatePhotographerSetting(
-        PhotographerRequest.PhotographerSetting photographerSetting) {
-        Long photographerId = GetAuthenticationInfo.getUserId();
+        PhotographerRequest.PhotographerSetting photographerSetting, long photographerId) {
         PhotographerSetting photographerSettingDocument = PhotographerSetting.builder()
             .photographerId(photographerId)
             .autoReservationAccept(photographerSetting.getAutoReservationAccept())
@@ -40,14 +37,13 @@ public class PhotographerService {
         photographerSettingRepository.updatePhotographerSetting(photographerSettingDocument);
     }
 
-    public PhotographerReservationNotice getReservationNotice() {
-        return photographerReservationNoticeRepository.findByPhotographerId(
-            GetAuthenticationInfo.getUserId());
+    public PhotographerReservationNotice getReservationNotice(long photographerId) {
+        return photographerReservationNoticeRepository.findByPhotographerId(photographerId);
     }
 
     public void updateReservationNotice(
-        PhotographerRequest.PhotographerReservationNotice photographerReservationNotice) {
-        Long photographerId = GetAuthenticationInfo.getUserId();
+        PhotographerRequest.PhotographerReservationNotice photographerReservationNotice,
+        long photographerId) {
         PhotographerReservationNotice photographerReservationNoticeDocument = PhotographerReservationNotice.builder()
             .photographerId(photographerId)
             .content(photographerReservationNotice.getContent())
@@ -56,14 +52,13 @@ public class PhotographerService {
             photographerReservationNoticeDocument);
     }
 
-    public PhotographerReservationLocation getReservationLocation() {
-        return photographerReservationLocationRepository.findByPhotographerId(
-            GetAuthenticationInfo.getUserId());
+    public PhotographerReservationLocation getReservationLocation(long photographerId) {
+        return photographerReservationLocationRepository.findByPhotographerId(photographerId);
     }
 
     public void updateReservationLocation(
-        PhotographerRequest.PhotographerReservationLocation photographerReservationLocation) {
-        Long photographerId = GetAuthenticationInfo.getUserId();
+        PhotographerRequest.PhotographerReservationLocation photographerReservationLocation,
+        long photographerId) {
         PhotographerReservationLocation photographerReservationLocationDocument = PhotographerReservationLocation.builder()
             .photographerId(photographerId)
             .content(photographerReservationLocation.getContent())


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[feat]: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #195 

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->

기존 코드에서는 시큐리티 컨텍스트를 통해 요청자의 id를 가져오는 로직이 있었습니다.

그러나, 특정 요청에서 필요한 값들을 추출하는 것은 컨트롤러의 역할입니다. 또한 시큐리티 컨텍스트를 가져오는 로직은 static 이기 때문에 테스트의 어려움이 있습니다.

따라서 사용자의 id 추출을 컨트롤러의 argument resolver에서 수행하고, 이 값을 서비스에 넘기는 형식으로 리팩토링 하였습니다.