### PR TITLE
[CICD] base image 교체 (#229)

### DIFF
--- a/authorization/Dockerfile
+++ b/authorization/Dockerfile
@@ -5,9 +5,11 @@ WORKDIR /app
 
 COPY gradlew .
 COPY gradle gradle
-COPY settings.gradle .
 COPY auth-shared auth-shared
 COPY authorization authorization
+
+RUN echo "include 'authorization'" > settings.gradle && \
+    echo "include 'auth-shared'" >> settings.gradle
 
 RUN chmod +x gradlew
 RUN ./gradlew :authorization:clean :authorization:build -x test --no-daemon

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -4,9 +4,11 @@ WORKDIR /app
 
 COPY gradlew .
 COPY gradle gradle
-COPY settings.gradle .
 COPY auth-shared auth-shared
 COPY gateway gateway
+
+RUN echo "include 'gateway'" > settings.gradle && \
+    echo "include 'auth-shared'" >> settings.gradle
 
 RUN chmod +x gradlew
 RUN ./gradlew :gateway:clean :gateway:build -x test --no-daemon


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[feat]: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #229

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->
base image를 교체했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 컨테이너 베이스 이미지를 더 최신의 에디션(eclipse-temurin 17)으로 교체했습니다.
  * 다중 스테이지 빌드를 유지하고 빌드 산출물을 /app/app.jar로 배치하도록 경로를 표준화했습니다.
  * UID/GID 10001의 비루트 전용 사용자 및 그룹을 도입하고 컨테이너를 해당 사용자로 실행하도록 설정했습니다.
  * 소유권·권한을 빌드 산출물에 적용하고 시작 명령을 절대 경로로 명확화했습니다.
  * 런타임 포트(8080)를 명시적으로 노출하고 빌드 설정 포함 구성을 자동 생성하도록 추가했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->